### PR TITLE
Use Google's Gson instead of quick-json

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
             <version>2.3</version>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
@@ -138,22 +138,18 @@
             <artifactId>plain-credentials</artifactId>
             <version>1.2</version>
         </dependency>
+        <!--  Gson: Java to Json conversion -->
         <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>20160212</version>
-        </dependency>
-        <dependency>
-          <groupId>com.json</groupId>
-          <artifactId>quick-json</artifactId>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+          <version>2.8.0</version>
           <scope>compile</scope>
-          <version>1.0.2.3</version>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-job</artifactId>
-            <version>2.3</version>
-            <scope>test</scope>
+          <groupId>org.jenkins-ci.plugins.workflow</groupId>
+          <artifactId>workflow-job</artifactId>
+          <version>2.3</version>
+          <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/api/HieraDataStore.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/api/HieraDataStore.java
@@ -6,7 +6,7 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import hudson.model.RootAction;
 import hudson.Extension;
-import org.json.*;
+import com.google.gson.Gson;
 import javax.servlet.ServletException;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
 
@@ -132,6 +132,6 @@ public class HieraDataStore implements RootAction {
       hash.put(key, valueHash);
     }
 
-    return new JSONObject(hash).toString();
+    return new Gson().toJson(hash);
   }
 }

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/HieraConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/HieraConfig.java
@@ -6,7 +6,6 @@ import hudson.security.ACL;
 import hudson.XmlFile;
 import hudson.model.Saveable;
 import jenkins.model.Jenkins;
-import org.json.*;
 import java.util.*;
 import java.util.HashMap;
 import java.io.Serializable;

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/CodeDeployStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/CodeDeployStep.java
@@ -16,6 +16,7 @@ import hudson.model.Item;
 import hudson.model.TaskListener;
 import jenkins.model.Jenkins;
 import javax.annotation.Nonnull;
+import com.google.gson.internal.LinkedTreeMap;
 
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
@@ -65,7 +66,7 @@ public final class CodeDeployStep extends PuppetEnterpriseStep implements Serial
     @StepContextParameter private transient TaskListener listener;
 
     @Override protected Void run() throws Exception {
-      HashMap body = new HashMap();
+      LinkedTreeMap body = new LinkedTreeMap();
       ArrayList environments = new ArrayList();
       environments.add(step.getEnvironment());
 
@@ -75,16 +76,16 @@ public final class CodeDeployStep extends PuppetEnterpriseStep implements Serial
       PEResponse result = step.request("/code-manager/v1/deploys", 8170, "POST", body);
 
       if (!step.isSuccessful(result)) {
-        HashMap error = null;
+        LinkedTreeMap error = null;
 
         // If we get a hash back, it usually means a problem with authentication.
         // Otherwise, it's an error from deploying the enviornment code.
-        if (result.getResponseBody() instanceof HashMap ) {
-          error = (HashMap) result.getResponseBody();
+        if (result.getResponseBody() instanceof LinkedTreeMap ) {
+          error = (LinkedTreeMap) result.getResponseBody();
         } else {
           ArrayList envResults = (ArrayList) result.getResponseBody();
-          HashMap firstHash = (HashMap) envResults.get(0);
-          error = (HashMap) firstHash.get("error");
+          LinkedTreeMap firstHash = (LinkedTreeMap) envResults.get(0);
+          error = (LinkedTreeMap) firstHash.get("error");
         }
 
         logger.log(Level.SEVERE, error.toString());
@@ -113,7 +114,7 @@ public final class CodeDeployStep extends PuppetEnterpriseStep implements Serial
 
       Iterator itr = responseList.iterator();
       while(itr.hasNext()) {
-        HashMap envResponse = (HashMap) itr.next();
+        LinkedTreeMap envResponse = (LinkedTreeMap) itr.next();
 
         if (envResponse.get("status").equals("failed")) {
           return false;
@@ -121,8 +122,8 @@ public final class CodeDeployStep extends PuppetEnterpriseStep implements Serial
       }
     }
 
-    if (responseBody instanceof HashMap) {
-      HashMap responseHash = (HashMap) responseBody;
+    if (responseBody instanceof LinkedTreeMap) {
+      LinkedTreeMap responseHash = (LinkedTreeMap) responseBody;
 
       if (responseHash.get("error") != null) {
         return false;

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/QueryStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/QueryStep.java
@@ -38,6 +38,7 @@ import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import com.google.gson.internal.LinkedTreeMap;
 
 import org.jenkinsci.plugins.puppetenterprise.PuppetEnterpriseManagement;
 import org.jenkinsci.plugins.puppetenterprise.models.PEResponse;
@@ -66,7 +67,7 @@ public final class QueryStep extends PuppetEnterpriseStep implements Serializabl
     @StepContextParameter private transient TaskListener listener;
 
     @Override protected ArrayList run() throws Exception {
-      HashMap body = new HashMap();
+      LinkedTreeMap body = new LinkedTreeMap();
       body.put("query", step.getQuery());
 
       PEResponse result = step.request("/pdb/query/v4", 8081, "POST", body);


### PR DESCRIPTION
Previous to this commit, quick-json was used to parse JSON from Puppet
Enterprise API calls. However, it turns out that library breaks on empty
arrays. It always assumes there should be a value. This commit replaces
the quick-json library with Google's Gson library.

One gotcha was Gson uses LinkedTreeMap for JSON hashes instead of
HashMap, so each instance of HashMap needed to be replaced.