### PR TITLE
Improve job reporting

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/PEException.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/PEException.java
@@ -11,23 +11,28 @@ public class PEException extends Exception {
   public PEException() { super(); }
 
   public PEException(String message) {
+    super(message);
     logger.log(Level.SEVERE, message);
   }
 
   public PEException(Integer code) {
+    super("API call to PE resulted in status code (" + code + ")");
     logger.log(Level.SEVERE, "API call to PE resulted in status code (" + code + ")");
   }
 
   public PEException(String message, Integer code) {
+    super(message);
     logger.log(Level.SEVERE, "PE API call resulted in code (" + code + ") and message \"" + message + "\"");
   }
 
   public PEException(String message, Integer code, TaskListener listener) {
+    super(message);
     logger.log(Level.SEVERE, "PE API call resulted in code (" + code + ") and message \"" + message + "\"");
     listener.getLogger().println("PE API call resulted in code (" + code + ") and message \"" + message + "\"");
   }
 
   public PEException(String message, TaskListener listener) {
+    super(message);
     logger.log(Level.SEVERE, message);
     listener.getLogger().println(message);
   }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/PuppetJobStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/PuppetJobStep.java
@@ -240,16 +240,65 @@ public final class PuppetJobStep extends PuppetEnterpriseStep implements Seriali
         }
       } while (!jobStatus.equals("finished") && !jobStatus.equals("stopped") && !jobStatus.equals("failed"));
 
+      PEResponse nodes_response = step.request("/orchestrator/v1/jobs/" + parseJobId(jobID) + "/nodes", 8143, "GET", null);
+      jobStatusResponseHash.put("nodes", (HashMap) nodes_response.getResponseBody());
+      jobStatusResponseHash.put("status", jobStatus);
+
       if (jobStatus.equals("failed") || jobStatus.equals("stopped")) {
-        throw new PEException("Job " + parseJobId(jobID) + " " + jobStatus, listener);
-      } else {
-        listener.getLogger().println("Successfully ran Puppet job " + parseJobId(jobID));
+        String message = "Puppet job " + parseJobId(jobID) + " " + jobStatus + "\n---------\n" + step.formatReport(jobStatusResponseHash);
+        listener.getLogger().println(message);
+        throw new PEException(message, listener);
       }
+
+      String message = "Successfully ran Puppet job " + parseJobId(jobID) + "\n---------\n" + step.formatReport(jobStatusResponseHash);
+      listener.getLogger().println(message);
 
       return null;
     }
 
     private static final long serialVersionUID = 1L;
+  }
+
+  public String formatReport(HashMap report) {
+    StringBuilder formattedReport = new StringBuilder();
+
+    formattedReport.append("Puppet Job Name: " + ((String) report.get("name")) + "\n");
+    formattedReport.append("Status: " + ((String) report.get("status")) + "\n");
+    formattedReport.append("Environment: " + ((String)((HashMap) report.get("environment")).get("name")) + "\n");
+    formattedReport.append("Nodes: " + (String) report.get("node_count") + "\n\n");
+
+    ArrayList<HashMap> nodes = (ArrayList) ((HashMap) report.get("nodes")).get("items");
+    for (HashMap node : nodes ) {
+      formattedReport.append((String) node.get("name") + "\n");
+
+      HashMap node_details = (HashMap) node.get("details");
+      HashMap metrics = (HashMap) node_details.get("metrics");
+      String failed = (String) metrics.get("failed");
+      String changed = (String) metrics.get("changed");
+      String skipped = (String) metrics.get("skipped");
+      String corrective = null;
+
+      if (metrics.get("corrective_change") != null) {
+        corrective = (String) metrics.get("corrective_change");
+      }
+
+      formattedReport.append("  Resource Events: ");
+      formattedReport.append(failed + " failed   ");
+      formattedReport.append(changed + " changed   ");
+
+      //PE versions prior to 2016.4 do not include corrective changes
+      if (corrective != null) {
+        formattedReport.append(corrective + " corrective   ");
+      }
+
+      formattedReport.append(skipped + " skipped    ");
+      formattedReport.append("\n");
+
+      formattedReport.append("  Report URL: " + (String) node_details.get("report-url") + "\n");
+      formattedReport.append("\n");
+    }
+
+    return formattedReport.toString();
   }
 
   public Boolean isSuccessful(PEResponse response) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/PuppetJobStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/PuppetJobStep.java
@@ -165,10 +165,9 @@ public final class PuppetJobStep extends PuppetEnterpriseStep implements Seriali
       if (!step.isSuccessful(result)) {
         String error = null;
 
-        //RBAC will return an error key on error
         if (responseHash.get("error") != null) {
-          if (responseHash.get("error") instanceof LinkedTreeMap) {
-            LinkedTreeMap errorHash = (LinkedTreeMap) responseHash.get("error");
+          if (responseHash.get("error") instanceof HashMap) {
+            HashMap errorHash = (HashMap) responseHash.get("error");
             error = errorHash.toString();
           } else if (responseHash.get("error") instanceof String) {
             String errorString = (String) responseHash.get("error");
@@ -179,11 +178,14 @@ public final class PuppetJobStep extends PuppetEnterpriseStep implements Seriali
           }
         }
 
+        if (responseHash.get("msg") != null) {
+          error = (String) responseHash.get("msg");
+        }
+
         if (result.getResponseCode() == 404 && error == null) {
           error = "Environment " + step.getEnvironment() + " not found";
         }
 
-        logger.log(Level.SEVERE, error);
         throw new PEException(error, result.getResponseCode());
       }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/HieraStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/HieraStepTest.java
@@ -80,7 +80,6 @@ public class HieraStepTest extends Assert {
       HttpResponse response = httpClient.execute(httpGet, localContext);
 
       String json = IOUtils.toString(response.getEntity().getContent());
-      System.out.println("RETURNED BODY WAS: " + json);
       if (response.getStatusLine().getStatusCode() != 404 && !json.isEmpty()) {
         Object responseBody = new Gson().fromJson(json, Object.class);
         responseHash = (LinkedTreeMap) responseBody;

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/PuppetJobStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/PuppetJobStepTest.java
@@ -185,6 +185,57 @@ public class PuppetJobStepTest extends Assert {
   }
 
   @Test
+  public void puppetJobNonExistantNodeFails() throws Exception {
+    mockOrchestratorService.stubFor(post(urlEqualTo("/orchestrator/v1/command/deploy"))
+        .withHeader("content-type", equalTo("application/json"))
+        .withHeader("X-Authentication", equalTo("super_secret_token_string"))
+        .willReturn(aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(getCommandDeployResponseString())));
+
+    mockOrchestratorService.stubFor(get(urlEqualTo("/orchestrator/v1/jobs/711"))
+        .withHeader("X-Authentication", equalTo("super_secret_token_string"))
+        .willReturn(aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(TestUtils.getFileContents(TestUtils.getAPIResonsesBasesPath() + "job_node_does_not_exist.json"))));
+
+    mockOrchestratorService.stubFor(get(urlEqualTo("/orchestrator/v1/jobs/711/nodes"))
+        .withHeader("X-Authentication", equalTo("super_secret_token_string"))
+        .willReturn(aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(TestUtils.getFileContents(TestUtils.getAPIResonsesBasesPath() + "nodes_does_not_exist.json"))));
+
+    story.addStep(new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        //Create a job where the credentials are defined as part of the job method call
+        WorkflowJob job = story.j.jenkins.createProject(WorkflowJob.class, "Puppet Job Using List of Nodes Where Node Does Not Exist Fails");
+        job.setDefinition(new CpsFlowDefinition(
+          "node { \n" +
+          "  puppet.credentials 'pe-test-token' \n" +
+          "  puppet.job 'production', nodes: ['doesnotexist'] \n" +
+          "}", true));
+        WorkflowRun result = job.scheduleBuild2(0).get();
+        story.j.assertBuildStatus(Result.FAILURE, result);
+
+        verify(postRequestedFor(urlMatching("/orchestrator/v1/command/deploy"))
+            .withRequestBody(equalToJson("{\"environment\": \"production\", \"noop\" : false}"))
+            .withHeader("X-Authentication", matching("super_secret_token_string"))
+            .withHeader("Content-Type", matching("application/json")));
+
+        verify(getRequestedFor(urlMatching("/orchestrator/v1/jobs/711"))
+            .withHeader("X-Authentication", matching("super_secret_token_string")));
+
+        verify(getRequestedFor(urlMatching("/orchestrator/v1/jobs/711/nodes"))
+            .withHeader("X-Authentication", matching("super_secret_token_string")));
+      }
+    });
+  }
+
+  @Test
   public void puppetJobFailsOnNoSuchEnvironment() throws Exception {
 
     mockOrchestratorService.stubFor(post(urlEqualTo("/orchestrator/v1/command/deploy"))

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/PuppetJobStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/PuppetJobStepTest.java
@@ -94,6 +94,10 @@ public class PuppetJobStepTest extends Assert {
     return TestUtils.getFileContents(TestUtils.getAPIResonsesBasesPath() + "job_deploy.json");
   }
 
+  private String getJobNodeResults() {
+    return TestUtils.getFileContents(TestUtils.getAPIResonsesBasesPath() + "job_node_results.json");
+  }
+
   private void stubJobDeploySuccessful() {
     mockOrchestratorService.stubFor(post(urlEqualTo("/orchestrator/v1/command/deploy"))
         .withHeader("content-type", equalTo("application/json"))
@@ -109,6 +113,13 @@ public class PuppetJobStepTest extends Assert {
             .withStatus(200)
             .withHeader("Content-Type", "application/json")
             .withBody(getJobDetailsString())));
+
+    mockOrchestratorService.stubFor(get(urlEqualTo("/orchestrator/v1/jobs/711/nodes"))
+        .withHeader("X-Authentication", equalTo("super_secret_token_string"))
+        .willReturn(aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(getJobNodeResults())));
   }
 
   @Test
@@ -136,8 +147,11 @@ public class PuppetJobStepTest extends Assert {
 
         verify(getRequestedFor(urlMatching("/orchestrator/v1/jobs/711"))
             .withHeader("X-Authentication", matching("super_secret_token_string")));
+
+        verify(getRequestedFor(urlMatching("/orchestrator/v1/jobs/711/nodes"))
+            .withHeader("X-Authentication", matching("super_secret_token_string")));
       }
-    });
+      });
   }
 
   @Test
@@ -162,6 +176,9 @@ public class PuppetJobStepTest extends Assert {
             .withHeader("Content-Type", matching("application/json")));
 
         verify(getRequestedFor(urlMatching("/orchestrator/v1/jobs/711"))
+            .withHeader("X-Authentication", matching("super_secret_token_string")));
+
+        verify(getRequestedFor(urlMatching("/orchestrator/v1/jobs/711/nodes"))
             .withHeader("X-Authentication", matching("super_secret_token_string")));
       }
     });

--- a/src/test/java/resources/api-responses/job_node_does_not_exist.json
+++ b/src/test/java/resources/api-responses/job_node_does_not_exist.json
@@ -1,0 +1,53 @@
+{
+  "report" : {
+    "id" : "https://master.inf.puppet.vm:8143/orchestrator/v1/jobs/711/report"
+  },
+  "name" : "711",
+  "events" : {
+    "id" : "https://master.inf.puppet.vm:8143/orchestrator/v1/jobs/711/events"
+  },
+  "state" : "failed",
+  "nodes" : {
+    "id" : "https://master.inf.puppet.vm:8143/orchestrator/v1/jobs/711/nodes"
+  },
+  "status" : [ {
+    "state" : "new",
+    "enter_time" : "2016-12-15T18:20:28Z",
+    "exit_time" : "2016-12-15T18:20:29Z"
+  }, {
+    "state" : "ready",
+    "enter_time" : "2016-12-15T18:20:29Z",
+    "exit_time" : "2016-12-15T18:20:29Z"
+  }, {
+    "state" : "running",
+    "enter_time" : "2016-12-15T18:20:29Z",
+    "exit_time" : "2016-12-15T18:20:29Z"
+  }, {
+    "state" : "failed",
+    "enter_time" : "2016-12-15T18:20:29Z",
+    "exit_time" : null
+  } ],
+  "id" : "https://master.inf.puppet.vm:8143/orchestrator/v1/jobs/711",
+  "environment" : {
+    "name" : "production"
+  },
+  "options" : {
+    "concurrency" : null,
+    "noop" : false,
+    "trace" : false,
+    "debug" : false,
+    "scope" : {
+      "nodes" : [ "doesnotexist" ]
+    },
+    "enforce_environment" : true,
+    "environment" : "production",
+    "evaltrace" : false,
+    "target" : "nodes"
+  },
+  "timestamp" : "2016-12-15T18:20:29Z",
+  "owner" : {
+    "id" : "aee1744a-a40e-4e27-b83b-c0bb27775374",
+    "login" : "casey"
+  },
+  "node_count" : 1
+}

--- a/src/test/java/resources/api-responses/job_node_results.json
+++ b/src/test/java/resources/api-responses/job_node_results.json
@@ -1,0 +1,223 @@
+{
+  "items" : [ {
+    "name" : "database-production.pdx.puppet.vm",
+    "transaction_uuid" : "9ffbbbfe-0337-4610-a9d7-e17c11813cdd",
+    "state" : "finished",
+    "timestamp" : "2016-12-15T07:42:02Z",
+    "details" : {
+      "metrics" : {
+        "corrective_change" : 0,
+        "out_of_sync" : 0,
+        "restarted" : 0,
+        "skipped" : 0,
+        "total" : 208,
+        "changed" : 0,
+        "scheduled" : 0,
+        "failed_to_restart" : 0,
+        "failed" : 0
+      },
+      "report-url" : "https://master.inf.puppet.vm/#/cm/report/c01241a705186428975ef9cb731e4b3ecf3cb428",
+      "hash" : "c01241a705186428975ef9cb731e4b3ecf3cb428",
+      "environment" : "production",
+      "message" : "Finished puppet run on database-production.pdx.puppet.vm - Success! "
+    }
+  }, {
+    "name" : "master.inf.puppet.vm",
+    "transaction_uuid" : "65b44f20-0f40-424f-8d64-63fdd9222056",
+    "state" : "finished",
+    "timestamp" : "2016-12-15T07:42:19Z",
+    "details" : {
+      "metrics" : {
+        "corrective_change" : 0,
+        "out_of_sync" : 0,
+        "restarted" : 0,
+        "skipped" : 0,
+        "total" : 845,
+        "changed" : 0,
+        "scheduled" : 0,
+        "failed_to_restart" : 0,
+        "failed" : 0
+      },
+      "report-url" : "https://master.inf.puppet.vm/#/cm/report/4a94d124151db7f06036d947d50774f520283dd4",
+      "hash" : "4a94d124151db7f06036d947d50774f520283dd4",
+      "environment" : "production",
+      "message" : "Finished puppet run on master.inf.puppet.vm - Success! "
+    }
+  }, {
+    "name" : "rgbank.pdx.puppet.vm",
+    "transaction_uuid" : "966a8783-7833-4c94-8c1c-7f6c6f554e4f",
+    "state" : "finished",
+    "timestamp" : "2016-12-15T07:42:04Z",
+    "details" : {
+      "metrics" : {
+        "corrective_change" : 0,
+        "out_of_sync" : 0,
+        "restarted" : 0,
+        "skipped" : 0,
+        "total" : 196,
+        "changed" : 0,
+        "scheduled" : 0,
+        "failed_to_restart" : 0,
+        "failed" : 0
+      },
+      "report-url" : "https://master.inf.puppet.vm/#/cm/report/e6c3aa14ce2289d41e2fe497bfb068e0d0d5f042",
+      "hash" : "e6c3aa14ce2289d41e2fe497bfb068e0d0d5f042",
+      "environment" : "production",
+      "message" : "Finished puppet run on rgbank.pdx.puppet.vm - Success! "
+    }
+  }, {
+    "name" : "jenkins.inf.puppet.vm",
+    "transaction_uuid" : "af6a367d-b733-41df-ac93-7509b654fa74",
+    "state" : "finished",
+    "timestamp" : "2016-12-15T07:42:04Z",
+    "details" : {
+      "metrics" : {
+        "corrective_change" : 0,
+        "out_of_sync" : 0,
+        "restarted" : 0,
+        "skipped" : 0,
+        "total" : 295,
+        "changed" : 0,
+        "scheduled" : 0,
+        "failed_to_restart" : 0,
+        "failed" : 0
+      },
+      "report-url" : "https://master.inf.puppet.vm/#/cm/report/24c21e3e91313a3004c0493f51dc2870e0a5ddd5",
+      "hash" : "24c21e3e91313a3004c0493f51dc2870e0a5ddd5",
+      "environment" : "production",
+      "message" : "Finished puppet run on jenkins.inf.puppet.vm - Success! "
+    }
+  }, {
+    "name" : "database-staging.pdx.puppet.vm",
+    "transaction_uuid" : "10c4ac6f-d763-46c8-bf36-86441e01f13d",
+    "state" : "finished",
+    "timestamp" : "2016-12-15T07:42:04Z",
+    "details" : {
+      "metrics" : {
+        "corrective_change" : 0,
+        "out_of_sync" : 0,
+        "restarted" : 0,
+        "skipped" : 0,
+        "total" : 208,
+        "changed" : 0,
+        "scheduled" : 0,
+        "failed_to_restart" : 0,
+        "failed" : 0
+      },
+      "report-url" : "https://master.inf.puppet.vm/#/cm/report/f6e58d210b1d63103e46be645e73f03c9733ecfc",
+      "hash" : "f6e58d210b1d63103e46be645e73f03c9733ecfc",
+      "environment" : "production",
+      "message" : "Finished puppet run on database-staging.pdx.puppet.vm - Success! "
+    }
+  }, {
+    "name" : "rgbank-staging.pdx.puppet.vm",
+    "transaction_uuid" : "5094da26-ae15-449c-96ea-c3350c597270",
+    "state" : "finished",
+    "timestamp" : "2016-12-15T07:42:22Z",
+    "details" : {
+      "metrics" : {
+        "corrective_change" : 0,
+        "out_of_sync" : 0,
+        "restarted" : 0,
+        "skipped" : 0,
+        "total" : 196,
+        "changed" : 0,
+        "scheduled" : 0,
+        "failed_to_restart" : 0,
+        "failed" : 0
+      },
+      "report-url" : "https://master.inf.puppet.vm/#/cm/report/8e02667d032ed95d8180c9b7f8d79552953f556b",
+      "hash" : "8e02667d032ed95d8180c9b7f8d79552953f556b",
+      "environment" : "production",
+      "message" : "Finished puppet run on rgbank-staging.pdx.puppet.vm - Success! "
+    }
+  }, {
+    "name" : "rgbank-appserver-01.pdx.puppet.vm",
+    "transaction_uuid" : "e52acd79-11fc-4248-8352-5ec59c2adc4b",
+    "state" : "finished",
+    "timestamp" : "2016-12-15T07:42:03Z",
+    "details" : {
+      "metrics" : {
+        "corrective_change" : 0,
+        "out_of_sync" : 0,
+        "restarted" : 0,
+        "skipped" : 0,
+        "total" : 233,
+        "changed" : 0,
+        "scheduled" : 0,
+        "failed_to_restart" : 0,
+        "failed" : 0
+      },
+      "report-url" : "https://master.inf.puppet.vm/#/cm/report/74809e2c6e1be237e936f6ca74f9d19ca7f8e9df",
+      "hash" : "74809e2c6e1be237e936f6ca74f9d19ca7f8e9df",
+      "environment" : "production",
+      "message" : "Finished puppet run on rgbank-appserver-01.pdx.puppet.vm - Success! "
+    }
+  }, {
+    "name" : "rgbank-dev.pdx.puppet.vm",
+    "transaction_uuid" : "dccbab20-16e3-49d0-97fe-d487fb876184",
+    "state" : "finished",
+    "timestamp" : "2016-12-15T07:42:02Z",
+    "details" : {
+      "metrics" : {
+        "corrective_change" : 0,
+        "out_of_sync" : 0,
+        "restarted" : 0,
+        "skipped" : 0,
+        "total" : 233,
+        "changed" : 0,
+        "scheduled" : 0,
+        "failed_to_restart" : 0,
+        "failed" : 0
+      },
+      "report-url" : "https://master.inf.puppet.vm/#/cm/report/b7e248bf062a9511f14bce55a4a29d7025f41030",
+      "hash" : "b7e248bf062a9511f14bce55a4a29d7025f41030",
+      "environment" : "production",
+      "message" : "Finished puppet run on rgbank-dev.pdx.puppet.vm - Success! "
+    }
+  }, {
+    "name" : "gitlab.inf.puppet.vm",
+    "transaction_uuid" : "6bbe5b3e-5311-4951-a681-5d2f58c5b7bb",
+    "state" : "finished",
+    "timestamp" : "2016-12-15T07:42:22Z",
+    "details" : {
+      "metrics" : {
+        "corrective_change" : 0,
+        "out_of_sync" : 0,
+        "restarted" : 0,
+        "skipped" : 0,
+        "total" : 172,
+        "changed" : 0,
+        "scheduled" : 0,
+        "failed_to_restart" : 0,
+        "failed" : 0
+      },
+      "report-url" : "https://master.inf.puppet.vm/#/cm/report/55ef6b21cea4b844e3f539b6c4f3a720dd7df072",
+      "hash" : "55ef6b21cea4b844e3f539b6c4f3a720dd7df072",
+      "environment" : "production",
+      "message" : "Finished puppet run on gitlab.inf.puppet.vm - Success! "
+    }
+  }, {
+    "name" : "rgbank-appserver-staging-01.pdx.puppet.vm",
+    "transaction_uuid" : "9a031239-8f71-436f-a72c-300a1e8025a9",
+    "state" : "finished",
+    "timestamp" : "2016-12-15T07:42:03Z",
+    "details" : {
+      "metrics" : {
+        "corrective_change" : 0,
+        "out_of_sync" : 0,
+        "restarted" : 0,
+        "skipped" : 0,
+        "total" : 233,
+        "changed" : 0,
+        "scheduled" : 0,
+        "failed_to_restart" : 0,
+        "failed" : 0
+      },
+      "report-url" : "https://master.inf.puppet.vm/#/cm/report/921599ed4f8b84a1e5a5f77254e54b1de6cfca37",
+      "hash" : "921599ed4f8b84a1e5a5f77254e54b1de6cfca37",
+      "environment" : "production",
+      "message" : "Finished puppet run on rgbank-appserver-staging-01.pdx.puppet.vm - Success! "
+    }
+  } ]
+}

--- a/src/test/java/resources/api-responses/nodes_does_not_exist.json
+++ b/src/test/java/resources/api-responses/nodes_does_not_exist.json
@@ -1,0 +1,11 @@
+{
+  "items" : [ {
+    "name" : "doesnotexist",
+    "transaction_uuid" : null,
+    "state" : "errored",
+    "timestamp" : "2016-12-15T18:20:29Z",
+    "details" : {
+      "message" : "Error running puppet on doesnotexist: doesnotexist is not connected to the PCP broker"
+    }
+  } ]
+}


### PR DESCRIPTION
This PR improves the reporting of Puppet orchestrator jobs in the Jenkins Pipeline job log. More errors are caught from the PE orchestrator API in addition to a report being generated so users can review what Puppet agents experienced change from the job. The report includes a link to the run report in PE.