### PR TITLE
Only show node run message in report if run could not take place

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/PuppetJobStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/PuppetJobStep.java
@@ -311,11 +311,13 @@ public final class PuppetJobStep extends PuppetEnterpriseStep implements Seriali
         formattedReport.append("  Report URL: " + node_details.get("report-url") + "\n");
         formattedReport.append("\n");
 
-      }
-
-      //If the node could not be run, we get a message key back instead of a metrics key
-      if (node_details.get("message") != null) {
-        formattedReport.append(node_details.get("message"));
+      } else {
+        //There's always a message, but it's only useful if the run was not able to take place,
+        //  which we'll know if there are no metrics.
+        if (node_details.get("message") != null) {
+          formattedReport.append(node_details.get("message") + "\n");
+          formattedReport.append("\n");
+        }
       }
 
     }


### PR DESCRIPTION
This PR fixes message wrapping issues in the agent run report shown in the job log. 