### PR TITLE
Refactor puppet.codeDeploy step

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetCodeManagerV1.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetCodeManagerV1.java
@@ -1,0 +1,43 @@
+package org.jenkinsci.plugins.puppetenterprise.apimanagers;
+
+import java.util.*;
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.jenkinsci.plugins.workflow.PEException;
+import org.jenkinsci.plugins.puppetenterprise.models.PuppetEnterpriseConfig;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.PERequest;
+
+public abstract class PuppetCodeManagerV1 extends PERequest {
+  private String getCodeManagerAddress() {
+    return PuppetEnterpriseConfig.getPuppetMasterUrl();
+  }
+
+  private Integer getCodeManagerPort() {
+    return 8170;
+  }
+
+  protected URI getURI(String endpoint) throws Exception {
+    String uriString = "https://" + getCodeManagerAddress() + ":" + getCodeManagerPort() + "/code-manager/v1" + endpoint;
+    URI uri = null;
+
+    try {
+      uri = new URI(uriString);
+    } catch(URISyntaxException e) {
+      StringBuilder message = new StringBuilder();
+
+      message.append("Bad Code Manager Service Configuration.\n");
+
+      if (getCodeManagerAddress() == null || getCodeManagerAddress().isEmpty()) {
+        message.append("The Puppet Enterprise master address has not been configured yet.\nConfigure the Puppet Enterprise page under Manage Jenkins.");
+      }
+
+      message.append("Service Address: " + getCodeManagerAddress() + "\n");
+      message.append("Service Port: " + getCodeManagerPort() + "\n");
+      message.append("Details: " + e.getMessage());
+
+      throw new Exception(message.toString());
+    }
+
+    return uri;
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetCodeManagerV1/CodeManagerDeploysV1.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetCodeManagerV1/CodeManagerDeploysV1.java
@@ -1,0 +1,64 @@
+package org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetcodemanagerv1;
+
+import java.io.*;
+import java.util.*;
+import java.net.*;
+import java.lang.reflect.Type;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.internal.LinkedTreeMap;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.annotations.SerializedName;
+import org.jenkinsci.plugins.puppetenterprise.models.PEResponse;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.PuppetCodeManagerV1;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetcodemanagerv1.CodeManagerEnvironmentV1;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetcodemanagerv1.CodeManagerEnvironmentErrorV1;
+
+public class CodeManagerDeploysV1 extends PuppetCodeManagerV1 {
+  private URI uri = null;
+  private CodeManagerDeploysRequest request = null;
+  private ArrayList<CodeManagerEnvironmentV1> deployedEnvironments = null;
+  Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").create();
+
+  public CodeManagerDeploysV1() throws Exception {
+    this.uri = getURI("/deploys");
+    this.request = new CodeManagerDeploysRequest();
+  }
+
+  public void setEnvironments(ArrayList environments) {
+    this.request.environments = environments;
+  }
+
+  public void setWait(Boolean wait) {
+    this.request.wait = wait;
+  }
+
+  public ArrayList<CodeManagerEnvironmentV1> getDeployedEnvironments() {
+    return this.deployedEnvironments;
+  }
+
+  public void execute() throws Exception {
+    PEResponse response = send(this.uri, this.request);
+
+    Type listOfEnvironmentsType = new TypeToken<ArrayList<CodeManagerEnvironmentV1>>(){}.getType();
+    this.deployedEnvironments = gson.fromJson(response.getJSON(), listOfEnvironmentsType);
+  }
+
+  public ArrayList<CodeManagerEnvironmentV1> getErrors() {
+    ArrayList<CodeManagerEnvironmentV1> errors = new ArrayList();
+
+    for (CodeManagerEnvironmentV1 environment : deployedEnvironments ) {
+      if (environment.hasError()) {
+        errors.add(environment);
+      }
+    }
+
+    return errors;
+  }
+
+  class CodeManagerDeploysRequest {
+    public ArrayList environments = null;
+    public Boolean wait = null;
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetCodeManagerV1/CodeManagerEnvironmentErrorV1.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetCodeManagerV1/CodeManagerEnvironmentErrorV1.java
@@ -1,0 +1,24 @@
+package org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetcodemanagerv1;
+
+import java.io.*;
+import com.google.gson.internal.LinkedTreeMap;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetcodemanagerv1.CodeManagerEnvironmentV1;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetcodemanagerv1.CodeManagerEnvironmentErrorV1;
+
+public class CodeManagerEnvironmentErrorV1 {
+  private String kind = null;
+  private String msg = null;
+  private LinkedTreeMap<String, Object> details = null;
+
+  public String getKind() {
+    return this.kind;
+  }
+
+  public String getMessage() {
+    return this.msg;
+  }
+
+  public LinkedTreeMap<String, Object> getDetails() {
+    return this.details;
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetCodeManagerV1/CodeManagerEnvironmentV1.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetCodeManagerV1/CodeManagerEnvironmentV1.java
@@ -1,0 +1,44 @@
+package org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetcodemanagerv1;
+
+import java.io.*;
+import com.google.gson.internal.LinkedTreeMap;
+import com.google.gson.annotations.SerializedName;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetcodemanagerv1.CodeManagerEnvironmentV1;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetcodemanagerv1.CodeManagerEnvironmentErrorV1;
+
+public class CodeManagerEnvironmentV1 {
+  @SerializedName("deploy-signature")
+  private String deploySignature = null;
+
+  @SerializedName("file-sync")
+  private LinkedTreeMap<String,String> fileSync = null;
+
+  private String environment = null;
+  private Integer id = null;
+  private String status = null;
+  private CodeManagerEnvironmentErrorV1 error = null;
+
+  public String getName() {
+    return this.environment;
+  }
+
+  public String getStatus() {
+    return this.status;
+  }
+
+  public Integer getID() {
+    return this.id;
+  }
+
+  public Boolean hasError() {
+    return (this.error != null);
+  }
+
+  public Boolean isSuccessful() {
+    return (this.error == null);
+  }
+
+  public CodeManagerEnvironmentErrorV1 getError() {
+    return this.error;
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetCodeManagerV1/CodeManagerException.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetCodeManagerV1/CodeManagerException.java
@@ -1,0 +1,31 @@
+package org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetcodemanagerv1;
+
+import com.google.gson.internal.LinkedTreeMap;
+
+public class CodeManagerException extends Exception {
+  private String kind = "";
+  private String message = "";
+  private LinkedTreeMap<String, String> subject = null;
+
+  public CodeManagerException(String kind, String message, LinkedTreeMap<String, String> subject) {
+    this.kind = kind;
+    this.message = message;
+    this.subject = subject;
+  }
+
+  public String getKind() {
+    return this.kind;
+  }
+
+  public String getMessage() {
+    return this.message;
+  }
+
+  public LinkedTreeMap<String, String> getSubject() {
+    if (this.subject == null) {
+      return new LinkedTreeMap();
+    }
+
+    return this.subject;
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetCodeManagerV1/CodeManagerRBACError.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetCodeManagerV1/CodeManagerRBACError.java
@@ -1,0 +1,21 @@
+package org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetcodemanagerv1;
+
+import com.google.gson.internal.LinkedTreeMap;
+
+public class CodeManagerRBACError {
+  private String kind = null;
+  private String msg = null;
+  private LinkedTreeMap<String,String> subject = null;
+
+  public String getKind() {
+    return this.kind;
+  }
+
+  public String getMessage() {
+    return this.msg;
+  }
+
+  public LinkedTreeMap<String,String> getSubject() {
+    return this.subject;
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PuppetCodeManager.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PuppetCodeManager.java
@@ -5,6 +5,7 @@ import java.util.*;
 import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetcodemanagerv1.CodeManagerDeploysV1;
 import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetcodemanagerv1.CodeManagerEnvironmentV1;
 import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetcodemanagerv1.CodeManagerEnvironmentErrorV1;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetcodemanagerv1.CodeManagerException;
 import org.jenkinsci.plugins.puppetenterprise.apimanagers.PERequest;
 import com.google.gson.internal.LinkedTreeMap;
 
@@ -42,7 +43,7 @@ public class PuppetCodeManager {
     return (errors.size() > 0);
   }
 
-  public void deploy() throws Exception {
+  public void deploy() throws CodeManagerException, Exception {
     CodeManagerDeploysV1 deploys = new CodeManagerDeploysV1();
     deploys.setEnvironments(this.environments);
     deploys.setWait(this.wait);

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PuppetCodeManager.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PuppetCodeManager.java
@@ -68,7 +68,7 @@ public class PuppetCodeManager {
 
       if (environment.hasError()) {
         CodeManagerEnvironmentErrorV1 error = environment.getError();
-        formattedReport.append("    Kind: " + error.getKind() + "\n");
+        formattedReport.append("    Kind:    " + error.getKind() + "\n");
         formattedReport.append("    Message: " + error.getMessage() + "\n");
 
         if (error.getDetails() != null) {

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PuppetCodeManager.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PuppetCodeManager.java
@@ -1,0 +1,81 @@
+package org.jenkinsci.plugins.puppetenterprise.models;
+
+import java.io.*;
+import java.util.*;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetcodemanagerv1.CodeManagerDeploysV1;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetcodemanagerv1.CodeManagerEnvironmentV1;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetcodemanagerv1.CodeManagerEnvironmentErrorV1;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.PERequest;
+import com.google.gson.internal.LinkedTreeMap;
+
+public class PuppetCodeManager {
+  private ArrayList<String> environments = new ArrayList();
+  private String token = "";
+  private Boolean wait = null;
+  private ArrayList<CodeManagerEnvironmentV1> errors = new ArrayList();
+  private ArrayList<CodeManagerEnvironmentV1> deployedEnvironments = new ArrayList();
+  private PrintStream logger = null;
+
+  public PuppetCodeManager() { }
+
+  public void setEnvironments(ArrayList environments) {
+    this.environments = environments;
+  }
+
+  public void setLogger(PrintStream logger) {
+    this.logger = logger;
+  }
+
+  public void setToken(String token) {
+    this.token = token;
+  }
+
+  public void setWait(Boolean wait) {
+    this.wait = wait;
+  }
+
+  public ArrayList<CodeManagerEnvironmentV1> getErrors() {
+    return this.errors;
+  }
+
+  public Boolean hasErrors() {
+    return (errors.size() > 0);
+  }
+
+  public void deploy() throws Exception {
+    CodeManagerDeploysV1 deploys = new CodeManagerDeploysV1();
+    deploys.setEnvironments(this.environments);
+    deploys.setWait(this.wait);
+    deploys.setToken(this.token);
+    deploys.execute();
+
+    this.deployedEnvironments = deploys.getDeployedEnvironments();
+    this.errors = deploys.getErrors();
+  }
+
+  public String formatReport() {
+    StringBuilder formattedReport = new StringBuilder();
+    Integer totalEnvironments = this.environments.size();
+    Integer failedEnvironments = this.errors.size();
+    Integer successfulEnvironments = totalEnvironments - failedEnvironments;
+
+    formattedReport.append("Puppet environments deployed: ");
+    formattedReport.append(successfulEnvironments + " successful. " + failedEnvironments + " failed.\n");
+
+    for (CodeManagerEnvironmentV1 environment : this.deployedEnvironments ) {
+      formattedReport.append("  " + environment.getName() + ": " + environment.getStatus() + "\n");
+
+      if (environment.hasError()) {
+        CodeManagerEnvironmentErrorV1 error = environment.getError();
+        formattedReport.append("    Kind: " + error.getKind() + "\n");
+        formattedReport.append("    Message: " + error.getMessage() + "\n");
+
+        if (error.getDetails() != null) {
+          formattedReport.append("    Details: " + error.getDetails().toString() + "\n");
+        }
+      }
+    }
+
+    return formattedReport.toString();
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/CodeDeployStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/CodeDeployStep.java
@@ -1,5 +1,7 @@
 package org.jenkinsci.plugins.workflow.steps;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.util.*;
 import com.google.inject.Inject;
 import hudson.Extension;
@@ -14,9 +16,9 @@ import org.apache.commons.lang.StringUtils;
 import hudson.model.Run;
 import hudson.model.Item;
 import hudson.model.TaskListener;
+import java.net.*;
 import jenkins.model.Jenkins;
 import javax.annotation.Nonnull;
-import com.google.gson.internal.LinkedTreeMap;
 
 import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
@@ -38,23 +40,44 @@ import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import com.google.gson.internal.LinkedTreeMap;
 
-import org.jenkinsci.plugins.puppetenterprise.PuppetEnterpriseManagement;
 import org.jenkinsci.plugins.puppetenterprise.models.PEResponse;
+import org.jenkinsci.plugins.puppetenterprise.models.PuppetCodeManager;
 import org.jenkinsci.plugins.workflow.PEException;
 
 public final class CodeDeployStep extends PuppetEnterpriseStep implements Serializable {
-
-  private static final Logger logger = Logger.getLogger(CodeDeployStep.class.getName());
-
-  private String environment = "";
+  private ArrayList<String> environments = new ArrayList();
+  private String credentialsId = "";
 
   @DataBoundSetter private void setEnvironment(String environment) {
-    this.environment = Util.fixEmpty(environment);
+    this.environments.add(environment);
   }
 
-  public String getEnvironment() {
-    return this.environment;
+  @DataBoundSetter private void setEnvironments(ArrayList environments) {
+    this.environments.addAll(environments);
+  }
+
+  //TODO: Move this back to the PuppetEnterpriseStep class when done refactoring
+  @DataBoundSetter public void setCredentialsId(String credentialsId) {
+    this.credentialsId = Util.fixEmpty(credentialsId);
+  }
+
+  public ArrayList<String> getEnvironments() {
+    return this.environments;
+  }
+
+  //TODO: Move this back to the PuppetEnterpriseStep class when done refactoring
+  private String getToken() {
+    return lookupCredentials(this.credentialsId).getSecret().toString();
+  }
+
+  //TODO: Move this back to the PuppetEnterpriseStep class when done refactoring
+  private static StringCredentials lookupCredentials(@Nonnull String credentialId) {
+    return CredentialsMatchers.firstOrNull(
+      CredentialsProvider.lookupCredentials(StringCredentials.class, Jenkins.getInstance(), ACL.SYSTEM, null),
+      CredentialsMatchers.withId(credentialId)
+    );
   }
 
   @DataBoundConstructor public CodeDeployStep() { }
@@ -66,71 +89,26 @@ public final class CodeDeployStep extends PuppetEnterpriseStep implements Serial
     @StepContextParameter private transient TaskListener listener;
 
     @Override protected Void run() throws Exception {
-      LinkedTreeMap body = new LinkedTreeMap();
-      ArrayList environments = new ArrayList();
-      environments.add(step.getEnvironment());
+      PuppetCodeManager codemanager = new PuppetCodeManager();
 
-      body.put("wait", true);
-      body.put("environments", environments);
+      codemanager.setEnvironments(step.getEnvironments());
+      codemanager.setToken(step.getToken());
+      codemanager.setWait(true);
+      codemanager.deploy();
 
-      PEResponse result = step.request("/code-manager/v1/deploys", 8170, "POST", body);
+      listener.getLogger().println(codemanager.formatReport());
 
-      if (!step.isSuccessful(result)) {
-        LinkedTreeMap error = null;
-
-        // If we get a hash back, it usually means a problem with authentication.
-        // Otherwise, it's an error from deploying the enviornment code.
-        if (result.getResponseBody() instanceof LinkedTreeMap ) {
-          error = (LinkedTreeMap) result.getResponseBody();
-        } else {
-          ArrayList envResults = (ArrayList) result.getResponseBody();
-          LinkedTreeMap firstHash = (LinkedTreeMap) envResults.get(0);
-          error = (LinkedTreeMap) firstHash.get("error");
-        }
-
-        logger.log(Level.SEVERE, error.toString());
-        throw new PEException(error.toString(), result.getResponseCode(), listener);
-      } else {
-        listener.getLogger().println("Successfully deployed " + environments + " Puppet environment code.");
-        logger.log(Level.INFO, "Successfully deployed " + environments + " Puppet environment code.");
+      if (codemanager.hasErrors()) {
+        Integer errorCount = codemanager.getErrors().size();
+        listener.getLogger().println("\n");
+        String message = errorCount.toString() + " Puppet environments failed to deploy.";
+        throw new PEException(message, listener);
       }
 
       return null;
     }
 
     private static final long serialVersionUID = 1L;
-  }
-
-  public Boolean isSuccessful(PEResponse response) {
-    Integer responseCode = response.getResponseCode();
-    Object responseBody = response.getResponseBody();
-
-    if (responseCode < 200 || responseCode >= 300) {
-      return false;
-    }
-
-    if (responseBody instanceof ArrayList) {
-      ArrayList responseList = (ArrayList) responseBody;
-
-      Iterator itr = responseList.iterator();
-      while(itr.hasNext()) {
-        LinkedTreeMap envResponse = (LinkedTreeMap) itr.next();
-
-        if (envResponse.get("status").equals("failed")) {
-          return false;
-        }
-      }
-    }
-
-    if (responseBody instanceof LinkedTreeMap) {
-      LinkedTreeMap responseHash = (LinkedTreeMap) responseBody;
-
-      if (responseHash.get("error") != null) {
-        return false;
-      }
-    }
-
-    return true;
   }
 
   @Extension public static final class DescriptorImpl extends AbstractStepDescriptorImpl {

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/CodeDeployStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/CodeDeployStep.java
@@ -1,7 +1,5 @@
 package org.jenkinsci.plugins.workflow.steps;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 import java.util.*;
 import com.google.inject.Inject;
 import hudson.Extension;


### PR DESCRIPTION
This PR refactors the puppet.codeDeploy step to match the API manager strategy introduced in PR #4. This refactor supports providing several environments to deploy at a single time, though that functionality is not yet exposed to the user.