### PR TITLE
Refactor puppet.query step

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetDBV4.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetDBV4.java
@@ -1,0 +1,43 @@
+package org.jenkinsci.plugins.puppetenterprise.apimanagers;
+
+import java.util.*;
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.jenkinsci.plugins.workflow.PEException;
+import org.jenkinsci.plugins.puppetenterprise.models.PuppetEnterpriseConfig;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.PERequest;
+
+public abstract class PuppetDBV4 extends PERequest {
+  private String getPuppetDBAddress() {
+    return PuppetEnterpriseConfig.getPuppetMasterUrl();
+  }
+
+  private Integer getPuppetDBPort() {
+    return 8081;
+  }
+
+  protected URI getURI(String endpoint) throws Exception {
+    String uriString = "https://" + getPuppetDBAddress() + ":" + getPuppetDBPort() + "/pdb" + endpoint;
+    URI uri = null;
+
+    try {
+      uri = new URI(uriString);
+    } catch(URISyntaxException e) {
+      StringBuilder message = new StringBuilder();
+
+      message.append("Bad PuppetDB Service Configuration.\n");
+
+      if (getPuppetDBAddress() == null || getPuppetDBAddress().isEmpty()) {
+        message.append("The Puppet Enterprise master address has not been configured yet.\nConfigure the Puppet Enterprise page under Manage Jenkins.");
+      }
+
+      message.append("Service Address: " + getPuppetDBAddress() + "\n");
+      message.append("Service Port: " + getPuppetDBPort() + "\n");
+      message.append("Details: " + e.getMessage());
+
+      throw new Exception(message.toString());
+    }
+
+    return uri;
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetDBV4/PuppetDBException.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetDBV4/PuppetDBException.java
@@ -1,0 +1,31 @@
+package org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetdbv4;
+
+import com.google.gson.internal.LinkedTreeMap;
+
+public class PuppetDBException extends Exception {
+  private String kind = "";
+  private String message = "";
+  private LinkedTreeMap<String, Object> details = null;
+
+  public PuppetDBException(String kind, String message, LinkedTreeMap<String, Object> details) {
+    this.kind = kind;
+    this.message = message;
+    this.details = details;
+  }
+
+  public String getKind() {
+    return this.kind;
+  }
+
+  public String getMessage() {
+    return this.message;
+  }
+
+  public LinkedTreeMap<String, Object> getDetails() {
+    if (this.details == null) {
+      return new LinkedTreeMap();
+    }
+
+    return this.details;
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetDBV4/PuppetDBQueryV4.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetDBV4/PuppetDBQueryV4.java
@@ -1,0 +1,104 @@
+package org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetdbv4;
+
+import java.io.*;
+import java.util.*;
+import java.net.*;
+import java.lang.reflect.Type;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.internal.LinkedTreeMap;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.annotations.SerializedName;
+import org.jenkinsci.plugins.puppetenterprise.models.PEResponse;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.PuppetDBV4;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetdbv4.PuppetDBException;
+
+public class PuppetDBQueryV4 extends PuppetDBV4 {
+  private URI uri = null;
+  private PuppetDBQueryRequest request = new PuppetDBQueryRequest();
+  private ArrayList results = new ArrayList();
+  Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").create();
+
+  public PuppetDBQueryV4() throws Exception {
+    this.uri = getURI("/query/v4");
+    this.request = new PuppetDBQueryRequest();
+  }
+
+  public void setQuery(String query) {
+    this.request.query = query;
+  }
+
+  public ArrayList getResults() {
+    return this.results;
+  }
+
+  public Boolean isSuccessful(PEResponse response) {
+    if (response.getResponseCode() == 400 || response.getResponseCode() == 500) {
+      return false;
+    }
+
+    return true;
+  }
+
+  public void execute() throws PuppetDBException, Exception {
+    PEResponse response = send(this.uri, this.request);
+
+    if (response.getResponseCode() == 401 || response.getResponseCode() == 403) {
+      PuppetDBRBACError error = gson.fromJson(response.getJSON(), PuppetDBRBACError.class);
+      throw new PuppetDBException(error.getKind(), error.getMessage(), error.getSubject());
+    }
+
+    if (isSuccessful(response)) {
+      this.results = gson.fromJson(response.getJSON(), ArrayList.class);
+    } else {
+      PuppetDBQueryError error = new PuppetDBQueryError(response.getJSON());
+      throw new PuppetDBException(error.getKind(), error.getMessage(), error.getDetails());
+    }
+  }
+
+  class PuppetDBRBACError {
+    private String kind = null;
+    private String msg = null;
+    private LinkedTreeMap<String,Object> subject = null;
+
+    public String getKind() {
+      return this.kind;
+    }
+
+    public String getMessage() {
+      return this.msg;
+    }
+
+    public LinkedTreeMap<String,Object> getSubject() {
+      return this.subject;
+    }
+  }
+
+  class PuppetDBQueryError {
+    private String kind = null;
+    private String message = null;
+    private LinkedTreeMap<String,Object> details = null;
+
+    public PuppetDBQueryError(String message) {
+      this.kind = "puppetlabs.puppdb/malformed-query";
+      this.message = message;
+    }
+
+    public String getKind() {
+      return this.kind;
+    }
+
+    public String getMessage() {
+      return this.message;
+    }
+
+    public LinkedTreeMap<String, Object> getDetails() {
+      return this.details;
+    }
+  }
+
+  class PuppetDBQueryRequest {
+    public String query = null;
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PQLQuery.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PQLQuery.java
@@ -1,0 +1,35 @@
+package org.jenkinsci.plugins.puppetenterprise.models;
+
+import java.io.*;
+import java.util.*;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetdbv4.PuppetDBQueryV4;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetdbv4.PuppetDBException;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.PERequest;
+import com.google.gson.internal.LinkedTreeMap;
+
+public class PQLQuery {
+  private ArrayList results = new ArrayList();
+  private String query = null;
+  private String token = null;
+
+  public void setToken(String token) {
+    this.token = token;
+  }
+
+  public void setQuery(String query) {
+    this.query = query;
+  }
+
+  public ArrayList getResults() {
+    return this.results;
+  }
+
+  public void run() throws PuppetDBException, Exception {
+    PuppetDBQueryV4 query = new PuppetDBQueryV4();
+    query.setQuery(this.query);
+    query.setToken(this.token);
+    query.execute();
+
+    this.results = query.getResults();
+  }
+}


### PR DESCRIPTION
This PR adds the API managers and query interface model introduced by PR #4. With PRs #4, #5 and this one, the refactoring of the steps themselves to the new API manager model is complete.

There is still clean up work to do before the entire refactor is complete, including adding tests for Puppet Enterprise <2016.4 to ensure the refactor hasn't introduced regressions.