### PR TITLE
Add test to ensure PQL queries are parsed correctly

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetDBV4/PuppetDBQueryV4.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetDBV4/PuppetDBQueryV4.java
@@ -18,6 +18,9 @@ public class PuppetDBQueryV4 extends PuppetDBV4 {
   private URI uri = null;
   private PuppetDBQueryRequest request = new PuppetDBQueryRequest();
   private ArrayList results = new ArrayList();
+  //Note that dates are not parsed out of the returned JSON since we have no models
+  // for GSON to know what should be parsed as a Date object.
+  // TODO: Figure out a way to enable Date parsing with GSON without models
   Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").create();
 
   public PuppetDBQueryV4() throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/QueryStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/QueryStepTest.java
@@ -115,13 +115,20 @@ public class QueryStepTest extends Assert {
           "node { \n" +
           "  puppet.credentials 'pe-test-token'\n" +
           "  results = puppet.query 'nodes {}'\n" +
-          "  assert results instanceof ArrayList \n" +
-          "  assert results[0].certname == 'gitlab.inf.puppet.vm' \n" +
+          "  println 'Root object is of type: ' + results.getClass()\n" +
+          "  println 'First object latest_report_corrective_change is of type: ' + results[0]['latest_report_corrective_change'].getClass()\n" +
+          "  println 'First object facts_timestamp is of type: ' + results[0]['facts_timestamp'].getClass()\n" +
+          "  println 'First certname is: ' + results[0].certname\n" +
           "}", true));
         WorkflowRun result = job.scheduleBuild2(0).get();
         story.j.assertBuildStatusSuccess(result);
         story.j.assertLogContains("nodes {}", result);
         story.j.assertLogContains("Query returned 10 results.", result);
+        story.j.assertLogContains("Root object is of type: class java.util.ArrayList", result);
+        story.j.assertLogContains("First object latest_report_corrective_change is of type: class java.lang.Boolean", result);
+        //TODO: The timestamp should be a Date object in a future release with breaking changes
+        story.j.assertLogContains("First object facts_timestamp is of type: class java.lang.String", result);
+        story.j.assertLogContains("First certname is: gitlab.inf.puppet.vm", result);
 
         verify(postRequestedFor(urlMatching("/pdb/query/v4"))
             .withRequestBody(equalToJson("{\"query\": \"nodes {}\"}"))


### PR DESCRIPTION
This PR adds tests to ensure PQL queries from the puppet.query step are parsed to Java objects correctly.  In order to ensure compatibility, date formats are parsed as strings, but in the future they should be parsed as Date objects. That will have to wait until a backwards breaking change can be introduced.