### PR TITLE
JENKINS-40812 Hiera permissions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.11</version>
+        <version>2.19</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -83,6 +83,18 @@
      </plugins>
     </build>
     <dependencies>
+        <dependency>
+          <groupId>org.jenkins-ci</groupId>
+          <artifactId>htmlunit</artifactId>
+          <version>2.6-jenkins-4</version>
+          <exclusions>
+            <exclusion>
+              <!--  hides JDK DOM classes in Eclipse -->
+              <groupId>xml-apis</groupId>
+              <artifactId>xml-apis</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
         <dependency>
           <groupId>com.github.tomakehurst</groupId>
           <artifactId>wiremock</artifactId>
@@ -170,18 +182,6 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>javadoc</artifactId>
             <version>1.3</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>junit</artifactId>
-            <version>1.9</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jvnet.mock-javamail</groupId>
-            <artifactId>mock-javamail</artifactId>
-            <version>1.9</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -84,12 +84,17 @@
     </build>
     <dependencies>
         <dependency>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>matrix-auth</artifactId>
+          <version>1.4</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
           <groupId>org.jenkins-ci</groupId>
           <artifactId>htmlunit</artifactId>
-          <version>2.6-jenkins-4</version>
+          <version>2.6-jenkins-6</version>
           <exclusions>
             <exclusion>
-              <!--  hides JDK DOM classes in Eclipse -->
               <groupId>xml-apis</groupId>
               <artifactId>xml-apis</artifactId>
             </exclusion>

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/api/HieraDataStore.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/api/HieraDataStore.java
@@ -120,7 +120,17 @@ public class HieraDataStore implements RootAction {
   }
 
   public void doLookup(StaplerRequest req, StaplerResponse rsp) throws IOException {
-    User.current().checkPermission(LOOKUP);
+    //If Anonymous request and anonymous requests do not have READ permission
+    if (User.current() == null && !User.get("Anonymous").hasPermission(LOOKUP)) {
+      rsp.setStatus(403);
+      return;
+    }
+
+    //If the session is authenticated but the user does not have LOOKUP permissions
+    if (User.current() != null && !User.current().hasPermission(LOOKUP)) {
+      rsp.setStatus(403);
+      return;
+    }
 
     net.sf.json.JSONObject form = null;
     Map parameters = null;

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/api/HieraDataStore.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/api/HieraDataStore.java
@@ -2,19 +2,41 @@ package org.jenkinsci.plugins.puppetenterprise.api;
 
 import java.io.*;
 import java.util.*;
+import java.util.Locale;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import hudson.model.RootAction;
+import hudson.model.User;
+import jenkins.model.Jenkins;
 import hudson.Extension;
 import com.google.gson.Gson;
 import javax.servlet.ServletException;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
+import hudson.security.Permission;
+import hudson.security.PermissionGroup;
+import hudson.security.PermissionScope;
 
+import org.jenkinsci.plugins.puppetenterprise.Messages;
 import org.jenkinsci.plugins.puppetenterprise.models.HieraConfig;
 
 @Extension
 public class HieraDataStore implements RootAction {
   private static final String ICON_PATH = "/plugin/puppet-enterprise-pipeline/images/cfg_logo.png";
+
+  private static final PermissionScope[] SCOPES =
+          new PermissionScope[]{PermissionScope.ITEM, PermissionScope.ITEM_GROUP, PermissionScope.JENKINS};
+
+  public static final PermissionGroup GROUP = new PermissionGroup(HieraDataStore.class,
+              Messages._HieraDataStore_PermissionGroupTitle());
+
+  public static final Permission DELETE = new Permission(GROUP, "Delete",
+              Messages._HieraDataStore_DeletePermissionDescription(), Permission.DELETE, true, SCOPES);
+
+  public static final Permission VIEW = new Permission(GROUP, "View",
+              Messages._HieraDataStore_ViewPermissionDescription(), Permission.READ, true, SCOPES);
+
+  public static final Permission LOOKUP = new Permission(GROUP, "Lookup",
+              Messages._HieraDataStore_LookupPermissionDescription(), Permission.READ, true, SCOPES);
 
   public HieraDataStore() {
     HieraConfig.loadGlobalConfig();
@@ -72,11 +94,13 @@ public class HieraDataStore implements RootAction {
 
   @JavaScriptMethod
   public void deleteScope(String scope) {
+    User.current().checkPermission(DELETE);
     HieraConfig.deleteScope(scope);
   }
 
   @JavaScriptMethod
   public void deleteKey(String key, String scope) {
+    User.current().checkPermission(DELETE);
     HieraConfig.deleteKey(key, scope);
   }
 
@@ -96,6 +120,8 @@ public class HieraDataStore implements RootAction {
   }
 
   public void doLookup(StaplerRequest req, StaplerResponse rsp) throws IOException {
+    User.current().checkPermission(LOOKUP);
+
     net.sf.json.JSONObject form = null;
     Map parameters = null;
 

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/api/HieraDataStore.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/api/HieraDataStore.java
@@ -121,7 +121,7 @@ public class HieraDataStore implements RootAction {
 
   public void doLookup(StaplerRequest req, StaplerResponse rsp) throws IOException {
     //If Anonymous request and anonymous requests do not have READ permission
-    if (User.current() == null && !User.get("Anonymous").hasPermission(LOOKUP)) {
+    if (User.current() == null && !User.get("anonymous").hasPermission(LOOKUP)) {
       rsp.setStatus(403);
       return;
     }

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/api/HieraDataStore.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/api/HieraDataStore.java
@@ -120,7 +120,7 @@ public class HieraDataStore implements RootAction {
   }
 
   public void doLookup(StaplerRequest req, StaplerResponse rsp) throws IOException {
-    //If Anonymous request and anonymous requests do not have READ permission
+    //If Anonymous request and anonymous requests do not have LOOKUP permission
     if (User.current() == null && !User.get("anonymous").hasPermission(LOOKUP)) {
       rsp.setStatus(403);
       return;

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/api/HieraDataStore.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/api/HieraDataStore.java
@@ -9,6 +9,8 @@ import hudson.model.RootAction;
 import hudson.model.User;
 import jenkins.model.Jenkins;
 import hudson.Extension;
+import hudson.Plugin;
+import hudson.model.Api;
 import com.google.gson.Gson;
 import javax.servlet.ServletException;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
@@ -34,9 +36,6 @@ public class HieraDataStore implements RootAction {
 
   public static final Permission VIEW = new Permission(GROUP, "View",
               Messages._HieraDataStore_ViewPermissionDescription(), Permission.READ, true, SCOPES);
-
-  public static final Permission LOOKUP = new Permission(GROUP, "Lookup",
-              Messages._HieraDataStore_LookupPermissionDescription(), Permission.READ, true, SCOPES);
 
   public HieraDataStore() {
     HieraConfig.loadGlobalConfig();
@@ -120,18 +119,6 @@ public class HieraDataStore implements RootAction {
   }
 
   public void doLookup(StaplerRequest req, StaplerResponse rsp) throws IOException {
-    //If Anonymous request and anonymous requests do not have LOOKUP permission
-    if (User.current() == null && !User.get("anonymous").hasPermission(LOOKUP)) {
-      rsp.setStatus(403);
-      return;
-    }
-
-    //If the session is authenticated but the user does not have LOOKUP permissions
-    if (User.current() != null && !User.current().hasPermission(LOOKUP)) {
-      rsp.setStatus(403);
-      return;
-    }
-
     net.sf.json.JSONObject form = null;
     Map parameters = null;
 

--- a/src/main/resources/org/jenkinsci/plugins/puppetenterprise/Messages.properties
+++ b/src/main/resources/org/jenkinsci/plugins/puppetenterprise/Messages.properties
@@ -1,0 +1,4 @@
+HieraDataStore.PermissionGroupTitle=Hiera
+HieraDataStore.DeletePermissionDescription=Permission to delete key/value pairs
+HieraDataStore.ViewPermissionDescription=Permission to view key/value pairs
+HieraDataStore.LookupPermissionDescription=Permission to request a value for a specific key in specific scope

--- a/src/main/resources/org/jenkinsci/plugins/puppetenterprise/api/HieraDataStore/index.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/puppetenterprise/api/HieraDataStore/index.jelly
@@ -3,7 +3,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
 <j:new var="h" className="hudson.Functions" />
 
-  <l:layout norefresh="true" css="/plugin/puppet-enterprise-pipeline/css/hiera.css">
+  <l:layout norefresh="true" css="/plugin/puppet-enterprise-pipeline/css/hiera.css" permission="${it.VIEW}">
     <st:bind value="${it.deleteScope}" var="backend"/>
     <l:header>
     </l:header>
@@ -92,11 +92,13 @@
           <table>
             <tr>
               <td class="scope-name">${scope}</td>
+              <j:if test="${h.hasPermission(it.DELETE)}">
               <td class="scope-delete">
                 <button id="${scope}-remove-button" onclick="deleteScope('${scope}')" class="danger delete delete-scope">Remove Scope</button>
                 <button id="${scope}-confirm-button" onclick="confirmDeleteScope('${scope}')" class="danger delete delete-confirm">Confirm Delete</button>
                 <button id="${scope}-cancel-button" onclick="cancelDeleteScope('${scope}')" class="danger delete delete-cancel">Cancel</button>
               </td>
+              </j:if>
             </tr>
           </table>
 
@@ -122,9 +124,11 @@
                     ${it.getKeySource(scope, key)}
                   </td>
                   <td class="key-pair-delete">
+                    <j:if test="${h.hasPermission(it.DELETE)}">
                     <button id="${scope}-${key}-remove-button" onclick="deleteKey('${key}','${scope}')" class="delete delete-key">Remove</button>
                     <button id="${scope}-${key}-confirm-button" onclick="confirmDeleteKey('${key}','${scope}')" class="delete delete-confirm">Confirm Delete</button>
                     <button id="${scope}-${key}-cancel-button" onclick="cancelDeleteKey('${key}','${scope}')" class="delete delete-cancel">Cancel</button>
+                    </j:if>
                   </td>
                 </tr>
               </f:repeatable>

--- a/src/test/java/org/jenkinsci/plugins/puppetenterprise/TestBase.java
+++ b/src/test/java/org/jenkinsci/plugins/puppetenterprise/TestBase.java
@@ -27,10 +27,12 @@ import org.jenkinsci.plugins.workflow.steps.CodeDeployStepTest;
 import org.jenkinsci.plugins.workflow.steps.PuppetJobStepTest;
 import org.jenkinsci.plugins.workflow.steps.HieraStepTest;
 import org.jenkinsci.plugins.workflow.steps.QueryStepTest;
+import org.jenkinsci.plugins.puppetenterprise.api.HieraDataStoreTest;
 import org.jenkinsci.plugins.puppetenterprise.TestUtils;
 
 @RunWith(Suite.class)
-@SuiteClasses({PuppetJobStepTest.class, CodeDeployStepTest.class, HieraStepTest.class, QueryStepTest.class})
+@SuiteClasses({PuppetJobStepTest.class, CodeDeployStepTest.class,
+  HieraStepTest.class, QueryStepTest.class, HieraDataStoreTest.class})
 public class TestBase {
 
   private static WireMockServer mockPuppetServer;

--- a/src/test/java/org/jenkinsci/plugins/puppetenterprise/api/HieraDataStoreTest.java
+++ b/src/test/java/org/jenkinsci/plugins/puppetenterprise/api/HieraDataStoreTest.java
@@ -1,0 +1,221 @@
+package org.jenkinsci.plugins.puppetenterprise.api;
+
+import java.net.*;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.model.Statement;
+import org.junit.rules.ExpectedException;
+import static org.junit.Assert.*;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jenkinsci.plugins.puppetenterprise.models.HieraConfig;
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.internal.LinkedTreeMap;
+import org.apache.http.*;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.*;
+import org.apache.http.client.entity.*;
+import org.apache.http.entity.*;
+import org.apache.http.client.methods.*;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.BasicHttpContext;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.html.HtmlButton;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
+import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
+import com.gargoylesoftware.htmlunit.html.HtmlPasswordInput;
+import com.gargoylesoftware.htmlunit.html.HtmlElement;
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.BrowserVersion;
+import com.gargoylesoftware.htmlunit.DefaultCredentialsProvider;
+import org.acegisecurity.Authentication;
+import jenkins.model.Jenkins;
+import hudson.model.User;
+import hudson.security.LegacyAuthorizationStrategy;
+import hudson.security.HudsonPrivateSecurityRealm;
+import hudson.security.FullControlOnceLoggedInAuthorizationStrategy;
+import hudson.security.GlobalMatrixAuthorizationStrategy;
+
+public class HieraDataStoreTest extends Assert {
+
+  class HTTPUnauthorized extends Exception {}
+
+  @Rule
+  public final ExpectedException exception = ExpectedException.none();
+
+  @Rule
+  public RestartableJenkinsRule story = new RestartableJenkinsRule();
+
+  private LinkedTreeMap lookup(String scope, String key, String user, String password) throws HTTPUnauthorized {
+    LinkedTreeMap responseHash = new LinkedTreeMap();
+
+    try {
+      String url = story.j.jenkins.getRootUrl() + "/hiera/lookup?scope=" + scope + "&key=" + key;
+      URL urlObj = new URL(url);
+      HttpGet httpGet = new HttpGet(url);
+      HttpClient httpClient = new DefaultHttpClient();
+      HttpContext localContext = new BasicHttpContext();
+
+      if (user != null && password != null) {
+        byte[] credentials = Base64.encodeBase64((user + ":" + password).getBytes());
+        httpGet.setHeader("Authorization", "Basic " + new String(credentials));
+      }
+
+      HttpResponse response = httpClient.execute(httpGet, localContext);
+      String json = IOUtils.toString(response.getEntity().getContent());
+
+      if (response.getStatusLine().getStatusCode() == 403) {
+        throw new HTTPUnauthorized();
+      }
+
+      if (response.getStatusLine().getStatusCode() != 404 && !json.isEmpty()) {
+        Object responseBody = new Gson().fromJson(json, Object.class);
+        responseHash = (LinkedTreeMap) responseBody;
+      }
+    } catch(java.net.MalformedURLException e) {
+      fail(e.getMessage());
+    } catch(java.io.IOException e) {
+      fail(e.getMessage());
+    }
+
+    return responseHash;
+  }
+
+  @Test
+  public void unauthorizedReadOnlyRequestsCannotDeleteKeys() throws Exception {
+    story.addStep(new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        HtmlPage hieraDataStorePage = null;
+
+        try {
+          story.j.jenkins.setSecurityRealm(story.j.createDummySecurityRealm());
+          story.j.jenkins.setAuthorizationStrategy(new LegacyAuthorizationStrategy());
+        } catch(java.lang.NullPointerException e) { e.printStackTrace(); }
+
+        HieraConfig.setKeyValue("testscope", "testkey", "Hiera Data Store Test", "testvalue");
+
+        try {
+          WebClient client = new WebClient();
+          client.setCssEnabled(false);
+          client.setThrowExceptionOnScriptError(false);
+          client.setJavaScriptEnabled(false);
+          hieraDataStorePage = (HtmlPage) client.getPage(story.j.jenkins.getRootUrl() + "/hiera/");
+        } catch(com.gargoylesoftware.htmlunit.ScriptException e) { }
+          catch(java.lang.NullPointerException e) { e.printStackTrace(); }
+
+        HtmlElement removeScopeLink = (HtmlElement) hieraDataStorePage.getElementById("testscope-remove-button");
+        assertNull(removeScopeLink);
+
+        HtmlElement removeKeyLink = (HtmlElement) hieraDataStorePage.getElementById("testscope-testkey-remove-button");
+        assertNull(removeKeyLink);
+      }
+    });
+  }
+
+  @Test
+  public void authorizedRequestsCanDeleteKeys() throws Exception {
+    story.addStep(new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        HtmlPage hieraDataStorePage = null;
+        WebClient client = new WebClient();
+        HudsonPrivateSecurityRealm realm = new HudsonPrivateSecurityRealm(false);
+
+        realm.createAccount("casey", "password");
+        story.j.jenkins.setSecurityRealm(realm);
+        story.j.jenkins.setAuthorizationStrategy(new FullControlOnceLoggedInAuthorizationStrategy());
+
+        byte[] credentials = Base64.encodeBase64(("casey:password").getBytes());
+
+        client.setCssEnabled(false);
+        client.setThrowExceptionOnScriptError(false);
+        client.setJavaScriptEnabled(false);
+        client.addRequestHeader("Authorization", "Basic " + new String(credentials));
+
+        hieraDataStorePage = (HtmlPage) client.getPage(story.j.jenkins.getRootUrl() + "/hiera/");
+
+        HieraConfig.setKeyValue("testscope", "testkey", "Hiera Data Store Test", "testvalue");
+
+        HtmlElement removeScopeLink = (HtmlElement) hieraDataStorePage.getElementById("testscope-remove-button");
+        assertNotNull(removeScopeLink);
+
+        HtmlElement removeKeyLink = (HtmlElement) hieraDataStorePage.getElementById("testscope-testkey-remove-button");
+        assertNotNull(removeKeyLink);
+      }
+    });
+  }
+
+  @Test
+  public void lookupAuthenticatedRequestsWithLOOKUPPermissionSucceeds() throws Exception {
+
+    story.addStep(new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        LinkedTreeMap response = new LinkedTreeMap();
+        GlobalMatrixAuthorizationStrategy authorizationStrategy = new GlobalMatrixAuthorizationStrategy();
+        HudsonPrivateSecurityRealm realm = new HudsonPrivateSecurityRealm(false);
+
+        realm.createAccount("casey", "password");
+
+        story.j.jenkins.setSecurityRealm(realm);
+        story.j.jenkins.setAuthorizationStrategy(authorizationStrategy);
+        authorizationStrategy.add(HieraDataStore.LOOKUP, "casey");
+        authorizationStrategy.add(Jenkins.READ, "casey");
+        HieraConfig.setKeyValue("testscope", "testkey", "Lookup Authenticated Request With Hiera/Lookup Permission Succeeds", "testvalue");
+
+        response = lookup("testscope", "testkey", "casey", "password");
+        assertEquals( (String) response.get("testkey"), "testvalue");
+      }
+    });
+  }
+
+  @Test
+  public void lookupAuthenticatedRequestsWithoutLOOKUPPermissionFails() throws Exception {
+
+    story.addStep(new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        LinkedTreeMap response = new LinkedTreeMap();
+        GlobalMatrixAuthorizationStrategy authorizationStrategy = new GlobalMatrixAuthorizationStrategy();
+        HudsonPrivateSecurityRealm realm = new HudsonPrivateSecurityRealm(false);
+
+        realm.createAccount("don", "password");
+
+        story.j.jenkins.setSecurityRealm(realm);
+        story.j.jenkins.setAuthorizationStrategy(authorizationStrategy);
+        authorizationStrategy.add(Jenkins.READ, "don");
+        HieraConfig.setKeyValue("testscope", "testkey", "Lookup Authenticated Request Without Hiera/Lookup Permission Fails", "testvalue");
+
+        exception.expect(HTTPUnauthorized.class);
+        response = lookup("testscope", "testkey", "don", "password");
+      }
+    });
+  }
+
+  @Test
+  public void lookupUnauthenticatedRequestsFails() throws Exception {
+
+    story.addStep(new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        LinkedTreeMap response = new LinkedTreeMap();
+        GlobalMatrixAuthorizationStrategy authorizationStrategy = new GlobalMatrixAuthorizationStrategy();
+        HudsonPrivateSecurityRealm realm = new HudsonPrivateSecurityRealm(false);
+
+        story.j.jenkins.setSecurityRealm(realm);
+        story.j.jenkins.setAuthorizationStrategy(authorizationStrategy);
+        HieraConfig.setKeyValue("testscope", "testkey", "Lookup Unauthenticated Request Fails", "testvalue");
+
+        exception.expect(HTTPUnauthorized.class);
+        response = lookup("testscope", "testkey", null, null);
+      }
+    });
+  }
+}

--- a/src/test/java/org/jenkinsci/plugins/puppetenterprise/api/HieraDataStoreTest.java
+++ b/src/test/java/org/jenkinsci/plugins/puppetenterprise/api/HieraDataStoreTest.java
@@ -153,7 +153,7 @@ public class HieraDataStoreTest extends Assert {
   }
 
   @Test
-  public void lookupAuthenticatedRequestsWithLOOKUPPermissionSucceeds() throws Exception {
+  public void lookupAuthenticatedRequestsWithREADPermissionSucceeds() throws Exception {
 
     story.addStep(new Statement() {
       @Override
@@ -166,7 +166,6 @@ public class HieraDataStoreTest extends Assert {
 
         story.j.jenkins.setSecurityRealm(realm);
         story.j.jenkins.setAuthorizationStrategy(authorizationStrategy);
-        authorizationStrategy.add(HieraDataStore.LOOKUP, "casey");
         authorizationStrategy.add(Jenkins.READ, "casey");
         HieraConfig.setKeyValue("testscope", "testkey", "Lookup Authenticated Request With Hiera/Lookup Permission Succeeds", "testvalue");
 
@@ -177,7 +176,7 @@ public class HieraDataStoreTest extends Assert {
   }
 
   @Test
-  public void lookupAuthenticatedRequestsWithoutLOOKUPPermissionFails() throws Exception {
+  public void lookupAuthenticatedRequestsWithoutREADPermissionFails() throws Exception {
 
     story.addStep(new Statement() {
       @Override
@@ -190,7 +189,6 @@ public class HieraDataStoreTest extends Assert {
 
         story.j.jenkins.setSecurityRealm(realm);
         story.j.jenkins.setAuthorizationStrategy(authorizationStrategy);
-        authorizationStrategy.add(Jenkins.READ, "don");
         HieraConfig.setKeyValue("testscope", "testkey", "Lookup Authenticated Request Without Hiera/Lookup Permission Fails", "testvalue");
 
         exception.expect(HTTPUnauthorized.class);


### PR DESCRIPTION
This PR provides a fix for JENKINS-40812 by introducing permissions management for the Hiera Data Store page. WIth this change, Jenkins users with read only permission can view the Hiera Data Store page, but cannot delete scopes or keys. If a matrix authorization system is being used, Jenkins users can be assigned Hiera/View and Hiera/Delete permissions to restrict who can see the Hiera Data Store contents and delete scopes/keys respectively.

No matter the authorization system used, Jenkins users with Overall/Read permissions can query the Hiera store for key/value pairs through the API (but cannot get a list of all the existing key/value pairs). This is not ideal and an improvement will be made in the future.