### PR TITLE
Fix CA retrieval bug

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PuppetEnterpriseConfig.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PuppetEnterpriseConfig.java
@@ -45,9 +45,14 @@ public final class PuppetEnterpriseConfig implements Serializable {
 
   public static void setPuppetMasterUrl(String url) throws IOException, java.net.UnknownHostException,
     java.security.NoSuchAlgorithmException, java.security.KeyStoreException, java.security.KeyManagementException, org.apache.http.conn.HttpHostConnectException  {
+    setPuppetMasterUrl(url, true);
+  }
+
+  public static void setPuppetMasterUrl(String url, Boolean retrieveCACertificate) throws IOException, java.net.UnknownHostException,
+    java.security.NoSuchAlgorithmException, java.security.KeyStoreException, java.security.KeyManagementException, org.apache.http.conn.HttpHostConnectException  {
     puppetMasterUrl = url;
 
-    if(puppetMasterCACertificate == null || puppetMasterCACertificate.isEmpty()) {
+    if (retrieveCACertificate) {
       puppetMasterCACertificate = retrievePuppetMasterCACertificate();
     }
 

--- a/src/test/java/org/jenkinsci/plugins/puppetenterprise/PuppetEnterpriseManagementTest.java
+++ b/src/test/java/org/jenkinsci/plugins/puppetenterprise/PuppetEnterpriseManagementTest.java
@@ -1,0 +1,49 @@
+package org.jenkinsci.plugins.puppetenterprise;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runners.model.Statement;
+import static org.junit.Assert.*;
+import org.jvnet.hudson.test.RestartableJenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.html.HtmlButton;
+import com.gargoylesoftware.htmlunit.html.HtmlInput;
+import com.gargoylesoftware.htmlunit.html.HtmlElement;
+import com.gargoylesoftware.htmlunit.WebClient;
+import org.jenkinsci.plugins.puppetenterprise.models.PuppetEnterpriseConfig;
+import org.jenkinsci.plugins.puppetenterprise.TestUtils;
+
+public class PuppetEnterpriseManagementTest extends Assert {
+  @Rule
+  public RestartableJenkinsRule story = new RestartableJenkinsRule();
+
+  @Test
+  public void setNewPuppetServerAddress() throws Exception {
+    story.addStep(new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        PuppetEnterpriseConfig.setPuppetMasterCACertificate("original CA string");
+        PuppetEnterpriseConfig.setPuppetMasterUrl("notlocalhost", false);
+
+        //TODO: Properly test this functionality by working through the configuration page
+        // WebClient client = new WebClient();
+        // HtmlPage page = client.getPage(story.j.jenkins.getRootUrl() + "/puppetenterprise/");
+        // HtmlInput addressField = (HtmlInput) page.getElementByName("_.masterAddress");
+        // HtmlButton saveButton = (HtmlButton) page.getElementById("yui-gen1-button");
+        //
+        // assertNotNull(addressField);
+        // assertNotNull(saveButton);
+        //
+        // addressField.setValueAttribute("localhost");
+        // saveButton.click();
+
+        PuppetEnterpriseConfig.setPuppetMasterUrl("localhost");
+
+        assertEquals("localhost", PuppetEnterpriseConfig.getPuppetMasterUrl());
+        assertEquals(TestUtils.getCACertificateString(), PuppetEnterpriseConfig.getPuppetMasterCACertificate());
+      }
+    });
+  }
+}

--- a/src/test/java/org/jenkinsci/plugins/puppetenterprise/TestBase.java
+++ b/src/test/java/org/jenkinsci/plugins/puppetenterprise/TestBase.java
@@ -32,7 +32,9 @@ import org.jenkinsci.plugins.puppetenterprise.TestUtils;
 
 @RunWith(Suite.class)
 @SuiteClasses({PuppetJobStepTest.class, CodeDeployStepTest.class,
-  HieraStepTest.class, QueryStepTest.class, HieraDataStoreTest.class})
+  HieraStepTest.class, QueryStepTest.class, HieraDataStoreTest.class,
+  PuppetEnterpriseManagementTest.class
+})
 public class TestBase {
 
   private static WireMockServer mockPuppetServer;


### PR DESCRIPTION
This PR introduces a fix for a bug where a CA certificate could not be updated.  When a user configures a Puppet server through the plugin's configuration page, the plugin downloads the CA certificate for the Puppet server and stores it for future communication with the Puppet server.  If the user configures a new Puppet server, the plugin would not download the new CA certificate.  This PR fixes that.