### PR TITLE
Improve job reporting

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetJobReportV1/PuppetJobReportNodeEventV1.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetJobReportV1/PuppetJobReportNodeEventV1.java
@@ -27,6 +27,11 @@ public class PuppetJobReportNodeEventV1 implements Serializable {
   private String certname = null;
   private String message = null;
 
+  public String getResourceName() {
+    String resource_type = (getResourceType().substring(0,1).toUpperCase() + getResourceType().substring(1));
+    return (resource_type + "[" + getResourceTitle() + "]");
+  }
+
   public String getNewValue() {
     return this.new_value;
   }

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetJobReportV1/PuppetJobReportNodeEventV1.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetJobReportV1/PuppetJobReportNodeEventV1.java
@@ -6,13 +6,13 @@ import java.util.Date;
 import com.google.gson.internal.LinkedTreeMap;
 
 public class PuppetJobReportNodeEventV1 implements Serializable {
-  private String new_value = null;
+  private Object new_value = null;
   private String report = null;
   private Boolean corrective_change = null;
   private Date run_start_time = null;
   private String property = null;
   private String file = null;
-  private String old_value = null;
+  private Object old_value = null;
   private String containing_class = null;
   private String line = null;
   private String resource_type = null;
@@ -32,8 +32,21 @@ public class PuppetJobReportNodeEventV1 implements Serializable {
     return (resource_type + "[" + getResourceTitle() + "]");
   }
 
-  public String getNewValue() {
-    return this.new_value;
+  public Object getNewValue() {
+    Object returnObject = null;
+
+    //Gson defaults to Double for numbers, which means int values returned
+    // by Puppet will show 1.0 intead of 1, for example. This checks if its
+    // a Double and converts it to a Integer if the number is cleanly divisible
+    if (this.new_value instanceof Double) {
+      if (((Double) this.new_value % 1) == 0) {
+        returnObject = (int) Math.round((Double) this.new_value);
+      }
+    } else {
+      returnObject = this.new_value;
+    }
+
+    return returnObject;
   }
 
   public String getReport() {
@@ -56,8 +69,21 @@ public class PuppetJobReportNodeEventV1 implements Serializable {
     return this.file;
   }
 
-  public String getOldValue() {
-    return this.old_value;
+  public Object getOldValue() {
+    Object returnObject = null;
+
+    //Gson defaults to Double for numbers, which means int values returned
+    // by Puppet will show 1.0 intead of 1, for example. This checks if its
+    // a Double and converts it to a Integer if the number is cleanly divisible
+    if (this.old_value instanceof Double) {
+      if (((Double) this.old_value % 1) == 0) {
+        returnObject = (int) Math.round((Double) this.old_value);
+      }
+    } else {
+      returnObject = this.old_value;
+    }
+
+    return returnObject;
   }
 
   public String getContainingClass() {

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetJobReportV1/PuppetJobReportNodeEventV1.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetJobReportV1/PuppetJobReportNodeEventV1.java
@@ -1,0 +1,109 @@
+package org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetorchestratorv1.puppetjobreportv1;
+
+import java.io.*;
+import java.util.*;
+import java.util.Date;
+import com.google.gson.internal.LinkedTreeMap;
+
+public class PuppetJobReportNodeEventV1 {
+  private String new_value = null;
+  private String report = null;
+  private Boolean corrective_change = null;
+  private Date run_start_time = null;
+  private String property = null;
+  private String file = null;
+  private String old_value = null;
+  private String containing_class = null;
+  private String line = null;
+  private String resource_type = null;
+  private String status = null;
+  private String configuration_version = null;
+  private String resource_title = null;
+  private String environment = null;
+  private Date timestamp = null;
+  private Date run_end_time = null;
+  private Date report_receive_time = null;
+  private ArrayList<String> containment_path = null;
+  private String certname = null;
+  private String message = null;
+
+  public String getNewValue() {
+    return this.new_value;
+  }
+
+  public String getReport() {
+    return this.report;
+  }
+
+  public Boolean getCorrectiveChange() {
+    return this.corrective_change;
+  }
+
+  public Date getRunStartTime() {
+    return this.run_start_time;
+  }
+
+  public String getProperty() {
+    return this.property;
+  }
+
+  public String getFile() {
+    return this.file;
+  }
+
+  public String getOldValue() {
+    return this.old_value;
+  }
+
+  public String getContainingClass() {
+    return this.containing_class;
+  }
+
+  public String getLine() {
+    return this.line;
+  }
+
+  public String getResourceType() {
+    return this.resource_type;
+  }
+
+  public String getStatus() {
+    return this.status;
+  }
+
+  public String getConfigurationVersion() {
+    return this.configuration_version;
+  }
+
+  public String getResourceTitle() {
+    return this.resource_title;
+  }
+
+  public String getEnvironment() {
+    return this.environment;
+  }
+
+  public Date getTimestamp() {
+    return this.timestamp;
+  }
+
+  public Date getRunEndTime() {
+    return this.run_end_time;
+  }
+
+  public Date getReportReceiveTime() {
+    return this.report_receive_time;
+  }
+
+  public ArrayList<String> getContainmentPath() {
+    return this.containment_path;
+  }
+
+  public String getCertname() {
+    return this.certname;
+  }
+
+  public String getMessage() {
+    return this.message;
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetJobReportV1/PuppetJobReportNodeEventV1.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetJobReportV1/PuppetJobReportNodeEventV1.java
@@ -5,7 +5,7 @@ import java.util.*;
 import java.util.Date;
 import com.google.gson.internal.LinkedTreeMap;
 
-public class PuppetJobReportNodeEventV1 {
+public class PuppetJobReportNodeEventV1 implements Serializable {
   private String new_value = null;
   private String report = null;
   private Boolean corrective_change = null;

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetJobReportV1/PuppetJobReportNodeMetricsV1.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetJobReportV1/PuppetJobReportNodeMetricsV1.java
@@ -5,7 +5,7 @@ import java.util.*;
 import java.util.Date;
 import com.google.gson.internal.LinkedTreeMap;
 
-public class PuppetJobReportNodeMetricsV1 {
+public class PuppetJobReportNodeMetricsV1 implements Serializable {
   private PuppetJobReportNodeMetricsResources resources = null;
   private LinkedTreeMap<String,Float> time = null;
   private PuppetJobReportNodeMetricsChanges changes = null;
@@ -15,7 +15,7 @@ public class PuppetJobReportNodeMetricsV1 {
     return this.time;
   }
 
-  class PuppetJobReportNodeMetricsResources {
+  class PuppetJobReportNodeMetricsResources implements Serializable {
     public Integer total = null;
     public Integer out_of_sync = null;
     public Integer corrective_change = null;
@@ -27,11 +27,11 @@ public class PuppetJobReportNodeMetricsV1 {
     public Integer skipped = null;
   }
 
-  class PuppetJobReportNodeMetricsChanges {
+  class PuppetJobReportNodeMetricsChanges implements Serializable {
     public Integer total = null;
   }
 
-  class PuppetJobReportNodeMetricsEvents {
+  class PuppetJobReportNodeMetricsEvents implements Serializable {
     public Integer failure = null;
     public Integer success = null;
     public Integer total = null;

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetJobReportV1/PuppetJobReportNodeMetricsV1.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetJobReportV1/PuppetJobReportNodeMetricsV1.java
@@ -1,0 +1,39 @@
+package org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetorchestratorv1.puppetjobreportv1;
+
+import java.io.*;
+import java.util.*;
+import java.util.Date;
+import com.google.gson.internal.LinkedTreeMap;
+
+public class PuppetJobReportNodeMetricsV1 {
+  private PuppetJobReportNodeMetricsResources resources = null;
+  private LinkedTreeMap<String,Float> time = null;
+  private PuppetJobReportNodeMetricsChanges changes = null;
+  private PuppetJobReportNodeMetricsEvents events = null;
+
+  public LinkedTreeMap<String,Float> getTime() {
+    return this.time;
+  }
+
+  class PuppetJobReportNodeMetricsResources {
+    public Integer total = null;
+    public Integer out_of_sync = null;
+    public Integer corrective_change = null;
+    public Integer failed = null;
+    public Integer scheduled = null;
+    public Integer restarted = null;
+    public Integer failed_to_restart = null;
+    public Integer changed = null;
+    public Integer skipped = null;
+  }
+
+  class PuppetJobReportNodeMetricsChanges {
+    public Integer total = null;
+  }
+
+  class PuppetJobReportNodeMetricsEvents {
+    public Integer failure = null;
+    public Integer success = null;
+    public Integer total = null;
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetJobReportV1/PuppetJobReportNodeV1.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetJobReportV1/PuppetJobReportNodeV1.java
@@ -15,6 +15,7 @@ public class PuppetJobReportNodeV1 implements Serializable {
   private String certname = null;
   private String transaction_uuid = null;
   private String environment = null;
+  private String configuration_version = null;
   private PuppetJobReportNodeMetricsV1 metrics = null;
 
   public String getNode() {
@@ -27,6 +28,10 @@ public class PuppetJobReportNodeV1 implements Serializable {
 
   public Date getTimestamp() {
     return this.timestamp;
+  }
+
+  public String getConfigurationVersion() {
+    return this.configuration_version;
   }
 
   public ArrayList<PuppetJobReportNodeEventV1> getEvents() {

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetJobReportV1/PuppetJobReportNodeV1.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetJobReportV1/PuppetJobReportNodeV1.java
@@ -1,0 +1,51 @@
+package org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetorchestratorv1.puppetjobreportv1;
+
+import java.io.*;
+import java.util.*;
+import java.util.Date;
+import com.google.gson.internal.LinkedTreeMap;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetorchestratorv1.puppetjobreportv1.PuppetJobReportNodeEventV1;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetorchestratorv1.puppetjobreportv1.PuppetJobReportNodeMetricsV1;
+
+public class PuppetJobReportNodeV1 {
+  private String node = null;
+  private String state = null;
+  private Date timestamp = null;
+  private ArrayList<PuppetJobReportNodeEventV1> events = null;
+  private String certname = null;
+  private String transaction_uuid = null;
+  private String environment = null;
+  private ArrayList<PuppetJobReportNodeMetricsV1> metrics = null;
+
+  public String getNode() {
+    return this.node;
+  }
+
+  public String getState() {
+    return this.state;
+  }
+
+  public Date getTimestamp() {
+    return this.timestamp;
+  }
+
+  public ArrayList<PuppetJobReportNodeEventV1> getEvents() {
+    return this.events;
+  }
+
+  public String getCertname() {
+    return this.certname;
+  }
+
+  public String getTransactionUuid() {
+    return this.transaction_uuid;
+  }
+
+  public String getEnvironment() {
+    return this.environment;
+  }
+
+  public ArrayList<PuppetJobReportNodeMetricsV1> getMetrics() {
+    return this.metrics;
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetJobReportV1/PuppetJobReportNodeV1.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetJobReportV1/PuppetJobReportNodeV1.java
@@ -7,15 +7,15 @@ import com.google.gson.internal.LinkedTreeMap;
 import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetorchestratorv1.puppetjobreportv1.PuppetJobReportNodeEventV1;
 import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetorchestratorv1.puppetjobreportv1.PuppetJobReportNodeMetricsV1;
 
-public class PuppetJobReportNodeV1 {
+public class PuppetJobReportNodeV1 implements Serializable {
   private String node = null;
   private String state = null;
   private Date timestamp = null;
-  private ArrayList<PuppetJobReportNodeEventV1> events = null;
+  private ArrayList<PuppetJobReportNodeEventV1> events = new ArrayList();
   private String certname = null;
   private String transaction_uuid = null;
   private String environment = null;
-  private ArrayList<PuppetJobReportNodeMetricsV1> metrics = null;
+  private PuppetJobReportNodeMetricsV1 metrics = null;
 
   public String getNode() {
     return this.node;
@@ -30,7 +30,13 @@ public class PuppetJobReportNodeV1 {
   }
 
   public ArrayList<PuppetJobReportNodeEventV1> getEvents() {
-    return this.events;
+    //For some reason the orchestrator return null
+    // for the events value instead of an empty array
+    if (this.events == null) {
+      return new ArrayList();
+    } else {
+      return this.events;
+    }
   }
 
   public String getCertname() {
@@ -45,7 +51,7 @@ public class PuppetJobReportNodeV1 {
     return this.environment;
   }
 
-  public ArrayList<PuppetJobReportNodeMetricsV1> getMetrics() {
+  public PuppetJobReportNodeMetricsV1 getMetrics() {
     return this.metrics;
   }
 }

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetJobReportV1/PuppetJobReportV1.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetJobReportV1/PuppetJobReportV1.java
@@ -1,0 +1,13 @@
+package org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetorchestratorv1.puppetjobreportv1;
+
+import java.io.*;
+import java.util.*;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetorchestratorv1.puppetjobreportv1.PuppetJobReportNodeV1;
+
+public class PuppetJobReportV1 {
+  private ArrayList<PuppetJobReportNodeV1> report = null;
+
+  public ArrayList<PuppetJobReportNodeV1> getReport() {
+    return this.report;
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetJobsIDV1.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetJobsIDV1.java
@@ -11,6 +11,7 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import org.jenkinsci.plugins.puppetenterprise.apimanagers.PEResponse;
 import org.jenkinsci.plugins.puppetenterprise.apimanagers.PuppetOrchestratorV1;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetorchestratorv1.puppetjobreportv1.*;
 import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetorchestratorv1.puppetnodev1.*;
 import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetorchestratorv1.PuppetOrchestratorException;
 
@@ -20,6 +21,7 @@ public class PuppetJobsIDV1 extends PuppetOrchestratorV1 {
   private String name = "";
   private String state = "";
   private ArrayList<PuppetNodeItemV1> nodes = new ArrayList();
+  private ArrayList<PuppetJobReportNodeV1> report = new ArrayList();
   private Integer nodeCount = null;
   private String environment = "";
   Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").create();
@@ -47,6 +49,20 @@ public class PuppetJobsIDV1 extends PuppetOrchestratorV1 {
 
   public String getName() {
     return this.name;
+  }
+
+  public ArrayList<PuppetJobReportNodeV1> getReport() throws URISyntaxException, Exception {
+    URI uri = response.getReportURL().toURI();
+    PEResponse peResponse = send(uri);
+
+    if (isSuccessful(peResponse)) {
+      report = gson.fromJson(peResponse.getJSON(), PuppetJobReportV1.class).getReport();
+    } else {
+      PuppetJobsIDError error = gson.fromJson(peResponse.getJSON(), PuppetJobsIDError.class);
+      throw new PuppetOrchestratorException(error.kind, error.msg, error.details);
+    }
+
+    return report;
   }
 
   public ArrayList<PuppetNodeItemV1> getNodes() throws URISyntaxException, Exception {

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetNodeV1/PuppetNodeItemV1.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetNodeV1/PuppetNodeItemV1.java
@@ -57,7 +57,7 @@ public class PuppetNodeItemV1 {
     private PuppetNodeMetricsV1 metrics = null;
     private String message = "";
     private String hash = "";
-    private String environment = "";
+    private String environment = null;
 
     public URL getReportURL() {
       return this.reportUrl;

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PuppetJob.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PuppetJob.java
@@ -247,7 +247,8 @@ public class PuppetJob {
         formattedReport.append("  Environment: " + node.getEnvironment() + "\n");
       }
 
-      if (node.getMetrics() != null) {
+      //There will be no metrics if the run failed
+      if (!node.getState().equals("failed")) {
         PuppetNodeMetricsV1 metrics = node.getMetrics();
 
         formattedReport.append("  Resource Events: ");

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PuppetJob.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PuppetJob.java
@@ -11,7 +11,7 @@ import org.jenkinsci.plugins.puppetenterprise.apimanagers.PERequest;
 import org.jenkinsci.plugins.puppetenterprise.models.UnknownPuppetJobReportType;
 import com.google.gson.internal.LinkedTreeMap;
 
-public class PuppetJob implements Serializable {
+public class PuppetJob {
   private String state = null;
   private String name = null;
   private String token = null;

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PuppetJob.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PuppetJob.java
@@ -238,7 +238,7 @@ public class PuppetJob {
       formattedReport.append("Environment: " + this.environment + "\n");
     }
 
-    formattedReport.append("Resource events node summary: " + this.nodeCount + "\n\n");
+    formattedReport.append("Nodes: " + this.nodeCount + "\n\n");
 
     for (PuppetNodeItemV1 node : this.nodes) {
       formattedReport.append(node.getName() + "\n");
@@ -272,24 +272,6 @@ public class PuppetJob {
           formattedReport.append("  " + node.getMessage() + "\n");
           formattedReport.append("\n");
         }
-      }
-    }
-
-    formattedReport.append("\n\nResource events details:\n\n");
-
-    for (PuppetJobReportNodeV1 reportnode : this.report) {
-      formattedReport.append(reportnode.getNode() + "\n");
-
-      if (reportnode.getEvents().size() > 0) {
-        for (PuppetJobReportNodeEventV1 event: reportnode.getEvents()) {
-          formattedReport.append("  " + event.getResourceType().toUpperCase() + "[" + event.getResourceTitle() + "]");
-          formattedReport.append("    Property: " + event.getProperty());
-          formattedReport.append("    Old value: " + event.getOldValue());
-          formattedReport.append("    New value: " + event.getNewValue());
-          formattedReport.append("    Message: " + event.getMessage());
-        }
-      } else {
-        formattedReport.append("  0 resource events");
       }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PuppetJob.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PuppetJob.java
@@ -147,6 +147,50 @@ public class PuppetJob {
     return (!this.state.equals("finished") && !this.state.equals("stopped") && !this.state.equals("failed"));
   }
 
+  public Integer getNodeCount() {
+    return this.nodeCount;
+  }
+
+  public LinkedTreeMap getScope() {
+    return this.scope;
+  }
+
+  public String getTarget() {
+    return this.target;
+  }
+
+  public String getEnvironment() {
+    return this.environment;
+  }
+
+  public Integer getConcurrency() {
+    return this.concurrency;
+  }
+
+  public Boolean getEnforceEnvironment() {
+    return this.enforceEnvironment;
+  }
+
+  public Boolean getDebug() {
+    return this.debug;
+  }
+
+  public Boolean getTrace() {
+    return this.trace;
+  }
+
+  public Boolean getNoop() {
+    return this.noop;
+  }
+
+  public Boolean getEvalTrace() {
+    return this.evalTrace;
+  }
+
+  public PuppetJobReport generateRunReport() {
+    return new PuppetJobReport(this);
+  }
+
   public void updateState() throws PuppetOrchestratorException, Exception {
     this.job.setToken(this.token);
     this.job.execute();
@@ -159,6 +203,14 @@ public class PuppetJob {
     updateState();
     updateNodes();
     updateReport();
+  }
+
+  public ArrayList<PuppetNodeItemV1> getNodes() {
+    return this.nodes;
+  }
+
+  public ArrayList<PuppetJobReportNodeV1> getNodeReports() {
+    return this.report;
   }
 
   private void updateNodes() throws PuppetOrchestratorException, Exception {

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PuppetJobReport.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PuppetJobReport.java
@@ -94,11 +94,11 @@ public class PuppetJobReport implements Serializable {
       formattedReport.append("    " + reportResource.getName()  + "\n");
 
       for (PuppetJobReportNodeEventV1 event: reportResource.getEvents()) {
-        formattedReport.append("      Certname: " + event.getCertname() + "\n");
-        formattedReport.append("      Property: " + event.getProperty() + "\n");
+        formattedReport.append("      Certname:  " + event.getCertname() + "\n");
+        formattedReport.append("      Property:  " + event.getProperty() + "\n");
         formattedReport.append("      Old value: " + event.getOldValue() + "\n");
         formattedReport.append("      New value: " + event.getNewValue() + "\n");
-        formattedReport.append("      Message: " + event.getMessage() + "\n\n");
+        formattedReport.append("      Message:   " + event.getMessage() + "\n\n");
       }
     }
 
@@ -116,10 +116,10 @@ public class PuppetJobReport implements Serializable {
       if (reportnode.getEvents().size() > 0) {
         for (PuppetJobReportNodeEventV1 event: reportnode.getEvents()) {
           formattedReport.append("    " + event.getResourceName()  + "\n");
-          formattedReport.append("      Property: " + event.getProperty() + "\n");
+          formattedReport.append("      Property:  " + event.getProperty() + "\n");
           formattedReport.append("      Old value: " + event.getOldValue() + "\n");
           formattedReport.append("      New value: " + event.getNewValue() + "\n");
-          formattedReport.append("      Message: " + event.getMessage() + "\n\n");
+          formattedReport.append("      Message:   " + event.getMessage() + "\n\n");
         }
       } else {
         formattedReport.append("    0 resource events");

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PuppetJobReport.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PuppetJobReport.java
@@ -66,7 +66,7 @@ public class PuppetJobReport implements Serializable {
       }
 
       //There will be no metrics if the run failed
-      if (!node.getState().equals("failed")) {
+      if (!node.getState().equals("failed") && !node.getState().equals("errored")) {
         PuppetNodeMetricsV1 metrics = node.getMetrics();
 
         formattedReport.append("  Resource Events: ");

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PuppetJobReport.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PuppetJobReport.java
@@ -91,8 +91,9 @@ public class PuppetJobReport implements Serializable {
     formattedReport.append("Resources with changes:\n\n");
 
     for (PuppetResource reportResource : collectResourceEvents()) {
+      formattedReport.append("    " + reportResource.getName()  + "\n");
+
       for (PuppetJobReportNodeEventV1 event: reportResource.getEvents()) {
-        formattedReport.append("    " + event.getResourceName()  + "\n");
         formattedReport.append("      Certname: " + event.getCertname() + "\n");
         formattedReport.append("      Property: " + event.getProperty() + "\n");
         formattedReport.append("      Old value: " + event.getOldValue() + "\n");
@@ -128,6 +129,24 @@ public class PuppetJobReport implements Serializable {
     return formattedReport.toString();
   }
 
+  //Returns -1 if not found
+  private Integer containsResource(ArrayList<PuppetResource> resources, PuppetResource resource) {
+    Integer index = -1;
+
+    //Don't bother looking if there's nothing to look for
+    if (resources.size() == 0) {
+      return index;
+    }
+
+    for (Integer i = 0; i < resources.size(); i = i + 1) {
+      if (resource.getName().equals(resources.get(i).getName())) {
+        index = i;
+      }
+    }
+
+    return index;
+  }
+
   private ArrayList<PuppetResource> collectResourceEvents() {
     ArrayList<PuppetResource> resources = new ArrayList();
 
@@ -135,8 +154,12 @@ public class PuppetJobReport implements Serializable {
       for (PuppetJobReportNodeEventV1 nodeEvent : reportnode.getEvents()) {
         PuppetResource resource = new PuppetResource(nodeEvent.getResourceName());
 
-        if (resources.contains(resource)) {
-          resources.get(resources.indexOf(resource)).addEvent(nodeEvent);
+        Integer resourceIndex = containsResource(resources, resource);
+        if (resourceIndex >= 0) {
+          resources.get(resourceIndex).addEvent(nodeEvent);
+        } else {
+          resource.addEvent(nodeEvent);
+          resources.add(resource);
         }
       }
     }

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PuppetJobReport.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PuppetJobReport.java
@@ -1,0 +1,167 @@
+package org.jenkinsci.plugins.puppetenterprise.models;
+
+import java.io.*;
+import java.util.*;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetorchestratorv1.puppetjobreportv1.*;
+import org.jenkinsci.plugins.puppetenterprise.models.PuppetJob;
+import com.google.gson.internal.LinkedTreeMap;
+
+public class PuppetJobReport implements Serializable {
+  private String name = null;
+  private String state = null;
+  private Integer nodeCount = null;
+  private LinkedTreeMap scope = new LinkedTreeMap();
+  private String target = null;
+  private String environment = null;
+  private Integer concurrency = null;
+  private Boolean enforceEnvironment = null;
+  private Boolean debug = null;
+  private Boolean trace = null;
+  private Boolean noop = null;
+  private Boolean evalTrace = null;
+  private ArrayList<PuppetJobReportNodeV1> nodeReports = null;
+
+  public PuppetJobReport(PuppetJob job) {
+    this.nodeReports = job.getNodeReports();
+    this.name = job.getName();
+    this.state = job.getState();
+    this.nodeCount = job.getNodeCount();
+    this.scope = job.getScope();
+    this.target = job.getTarget();
+    this.environment = job.getEnvironment();
+    this.concurrency = job.getConcurrency();
+    this.enforceEnvironment = job.getEnforceEnvironment();
+    this.debug = job.getDebug();
+    this.trace = job.getTrace();
+    this.evalTrace = job.getEvalTrace();
+  }
+
+  public String getName() {
+    return this.name;
+  }
+
+  public String getState() {
+    return this.state;
+  }
+
+  public Integer getNodeCount() {
+    return this.nodeCount;
+  }
+
+  public LinkedTreeMap getScope() {
+    return this.scope;
+  }
+
+  public String getTarget() {
+    return this.target;
+  }
+
+  public String getEnvironment() {
+    return this.environment;
+  }
+
+  public Integer getConcurrency() {
+    return this.concurrency;
+  }
+
+  public Boolean getEnforceEnvironment() {
+    return this.enforceEnvironment;
+  }
+
+  public Boolean getDebug() {
+    return this.debug;
+  }
+
+  public Boolean getTrace() {
+    return this.trace;
+  }
+
+  public Boolean getNoop() {
+    return this.noop;
+  }
+
+  public Boolean getEvalTrace() {
+    return this.evalTrace;
+  }
+
+  public String formatResourcesReport() {
+    StringBuilder formattedReport = new StringBuilder();
+
+    formattedReport.append("Resources with changes:\n\n");
+
+    for (PuppetResource reportResource : collectResourceEvents()) {
+      for (PuppetJobReportNodeEventV1 event: reportResource.getEvents()) {
+        formattedReport.append("    " + event.getResourceName()  + "\n");
+        formattedReport.append("      Certname: " + event.getCertname() + "\n");
+        formattedReport.append("      Property: " + event.getProperty() + "\n");
+        formattedReport.append("      Old value: " + event.getOldValue() + "\n");
+        formattedReport.append("      New value: " + event.getNewValue() + "\n");
+        formattedReport.append("      Message: " + event.getMessage() + "\n\n");
+      }
+    }
+
+    return formattedReport.toString();
+  }
+
+  public String formatNodesReport() {
+    StringBuilder formattedReport = new StringBuilder();
+
+    formattedReport.append("Nodes with changes:\n\n");
+
+    for (PuppetJobReportNodeV1 reportnode : this.nodeReports) {
+      formattedReport.append("  " + reportnode.getNode() + "\n");
+
+      if (reportnode.getEvents().size() > 0) {
+        for (PuppetJobReportNodeEventV1 event: reportnode.getEvents()) {
+          formattedReport.append("    " + event.getResourceName()  + "\n");
+          formattedReport.append("      Property: " + event.getProperty() + "\n");
+          formattedReport.append("      Old value: " + event.getOldValue() + "\n");
+          formattedReport.append("      New value: " + event.getNewValue() + "\n");
+          formattedReport.append("      Message: " + event.getMessage() + "\n\n");
+        }
+      } else {
+        formattedReport.append("    0 resource events");
+      }
+    }
+
+    return formattedReport.toString();
+  }
+
+  private ArrayList<PuppetResource> collectResourceEvents() {
+    ArrayList<PuppetResource> resources = new ArrayList();
+
+    for (PuppetJobReportNodeV1 reportnode: this.nodeReports) {
+      for (PuppetJobReportNodeEventV1 nodeEvent : reportnode.getEvents()) {
+        PuppetResource resource = new PuppetResource(nodeEvent.getResourceName());
+
+        if (resources.contains(resource)) {
+          resources.get(resources.indexOf(resource)).addEvent(nodeEvent);
+        }
+      }
+    }
+
+    return resources;
+  }
+
+  class PuppetResource implements Serializable {
+    private ArrayList<PuppetJobReportNodeEventV1> events = new ArrayList();
+    private String name = null;
+
+    public PuppetResource(String name) {
+      this.name = name;
+    }
+
+    public String getName() {
+      return this.name;
+    }
+
+    public ArrayList<PuppetJobReportNodeEventV1> getEvents() {
+      return this.events;
+    }
+
+    public void addEvent(PuppetJobReportNodeEventV1 event) {
+      events.add(event);
+    }
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/UnknownPuppetJobReportType.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/UnknownPuppetJobReportType.java
@@ -1,0 +1,7 @@
+package org.jenkinsci.plugins.puppetenterprise.models;
+
+public class UnknownPuppetJobReportType extends Exception {
+  public UnknownPuppetJobReportType(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/PuppetDSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/PuppetDSL.java
@@ -34,20 +34,6 @@ import org.jenkinsci.plugins.workflow.cps.GlobalVariable;
         "method java.lang.Class isInstance java.lang.Object",
         "method java.lang.Throwable getMessage",
         "staticMethod java.lang.System getenv java.lang.String",
-        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport formatResourcesReport",
-        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport formatNodesReport",
-        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport getName",
-        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport getState",
-        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport getNodeCount",
-        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport getScope",
-        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport getTarget",
-        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport getEnvironment",
-        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport getConcurrency",
-        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport getEnforceEnvironment",
-        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport getDebug",
-        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport getTrace",
-        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport getNoop",
-        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport getEvalTrace",
         "method groovy.lang.GroovyObject invokeMethod java.lang.String java.lang.Object"));
     }
   }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/PuppetDSL.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/PuppetDSL.java
@@ -34,6 +34,20 @@ import org.jenkinsci.plugins.workflow.cps.GlobalVariable;
         "method java.lang.Class isInstance java.lang.Object",
         "method java.lang.Throwable getMessage",
         "staticMethod java.lang.System getenv java.lang.String",
+        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport formatResourcesReport",
+        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport formatNodesReport",
+        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport getName",
+        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport getState",
+        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport getNodeCount",
+        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport getScope",
+        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport getTarget",
+        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport getEnvironment",
+        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport getConcurrency",
+        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport getEnforceEnvironment",
+        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport getDebug",
+        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport getTrace",
+        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport getNoop",
+        "method org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport getEvalTrace",
         "method groovy.lang.GroovyObject invokeMethod java.lang.String java.lang.Object"));
     }
   }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/PuppetJobStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/PuppetJobStep.java
@@ -164,6 +164,16 @@ public final class PuppetJobStep extends PuppetEnterpriseStep implements Seriali
           listener.getLogger().println(job.generateReport(step.getReports()));
         } catch(UnknownPuppetJobReportType e) {
           throw new Exception(e.getMessage());
+        } catch(Exception e) {
+          StringBuilder bug = new StringBuilder();
+          bug.append("You found a bug! The Puppet Enterprise plugin received something ");
+          bug.append("in a job report it wasn't expecting. Please file a ticket here: ");
+          bug.append("https://issues.jenkins-ci.org/browse/JENKINS-42899?jql=project%20%3D%20JENKINS%20AND%20component%20%3D%20'puppet-enterprise-pipeline-plugin'\n\n");
+          bug.append("Include the following information:\n");
+          bug.append("Exception Type: " + e.getClass().getSimpleName() + "\n");
+          bug.append("Exception Message: " + e.getMessage() + "\n");
+
+          throw new Exception(bug.toString());
         }
 
         if (job.failed() || job.stopped()) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/PuppetJobStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/PuppetJobStep.java
@@ -172,7 +172,22 @@ public final class PuppetJobStep extends PuppetEnterpriseStep implements Seriali
         throw new PEException(message.toString(), listener);
       }
 
-      return job.generateRunReport();
+      PuppetJobReport jobResult = null;
+
+      try {
+        jobResult = job.generateRunReport();
+      } catch(Exception e) {
+        throw new PEException("Could not generate Puppet job report object. Reason given: " + e.getMessage(), listener);
+      }
+
+      //If it's null it will be impossible for the user to know if it's them or the plugin.
+      // It should never be null, but if it ever is, it's better to let the user know it's
+      // not their fault.
+      if (jobResult == null) {
+        throw new PEException("Could not generate Puppet job report object. Object returned null for unknown reasons.", listener);
+      }
+
+      return jobResult;
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/PuppetJobStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/PuppetJobStep.java
@@ -44,6 +44,7 @@ import com.google.gson.internal.LinkedTreeMap;
 
 import org.jenkinsci.plugins.puppetenterprise.PuppetEnterpriseManagement;
 import org.jenkinsci.plugins.puppetenterprise.models.PuppetJob;
+import org.jenkinsci.plugins.puppetenterprise.models.PuppetJobReport;
 import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetorchestratorv1.PuppetOrchestratorException;
 import org.jenkinsci.plugins.puppetenterprise.models.PEException;
 
@@ -116,7 +117,7 @@ public final class PuppetJobStep extends PuppetEnterpriseStep implements Seriali
 
   @DataBoundConstructor public PuppetJobStep() { }
 
-  public static class PuppetJobStepExecution extends AbstractSynchronousStepExecution<Void> {
+  public static class PuppetJobStepExecution extends AbstractSynchronousStepExecution<PuppetJobReport> {
 
     @Inject private transient PuppetJobStep step;
     @StepContextParameter private transient Run<?, ?> run;
@@ -126,7 +127,7 @@ public final class PuppetJobStep extends PuppetEnterpriseStep implements Seriali
       value = "DLS_DEAD_LOCAL_STORE",
       justification = "Findbugs is wrong. The variable is not a dead store."
     )
-    @Override protected Void run() throws Exception {
+    @Override protected PuppetJobReport run() throws Exception {
       PuppetJob job = new PuppetJob();
       job.setConcurrency(step.getConcurrency());
       job.setNoop(step.getNoop());
@@ -171,7 +172,7 @@ public final class PuppetJobStep extends PuppetEnterpriseStep implements Seriali
         throw new PEException(message.toString(), listener);
       }
 
-      return null;
+      return job.generateRunReport();
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/PuppetJobStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/PuppetJobStep.java
@@ -58,6 +58,7 @@ public final class PuppetJobStep extends PuppetEnterpriseStep implements Seriali
   private Boolean noop = false;
   private String environment = null;
   private String credentialsId = "";
+  private Boolean failOnFailure = true;
 
   @DataBoundSetter private void setTarget(String target) {
     this.target = Util.fixEmpty(target);
@@ -77,6 +78,10 @@ public final class PuppetJobStep extends PuppetEnterpriseStep implements Seriali
 
   @DataBoundSetter private void setQuery(String query) {
     this.query = query;
+  }
+
+  @DataBoundSetter private void setFailOnFailure(Boolean failOnFailure) {
+    this.failOnFailure = failOnFailure;
   }
 
   @DataBoundSetter private void setNodes(ArrayList nodes) {
@@ -113,6 +118,10 @@ public final class PuppetJobStep extends PuppetEnterpriseStep implements Seriali
 
   public Boolean getNoop() {
     return this.noop;
+  }
+
+  public Boolean getFailOnFailure() {
+    return this.failOnFailure;
   }
 
   @DataBoundConstructor public PuppetJobStep() { }
@@ -153,8 +162,15 @@ public final class PuppetJobStep extends PuppetEnterpriseStep implements Seriali
 
         listener.getLogger().println(job.formatReport());
 
+        //If the user does not want to fail the
+        // Jenkins job if the Puppet job fails, then
+        // just print an error instead
         if (job.failed() || job.stopped()) {
-          throw new Exception(summary);
+          if (step.getFailOnFailure()) {
+            throw new Exception(summary);
+          } else {
+            listener.error(summary);
+          }
         }
       } catch(PuppetOrchestratorException e) {
         StringBuilder message = new StringBuilder();

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/PuppetJobStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/PuppetJobStep.java
@@ -145,14 +145,11 @@ public final class PuppetJobStep extends PuppetEnterpriseStep implements Seriali
       }
 
       try {
-        StringBuilder message = new StringBuilder();
         String summary = "";
 
         job.run();
 
-        summary = "Puppet job " + job.getName() + " " + job.getState() + "\n---------\n";
-        message.append(summary);
-        message.append(job.formatReport());
+        summary = "Puppet job " + job.getName() + " " + job.getState() + "\n";
 
         listener.getLogger().println(job.formatReport());
 

--- a/src/main/resources/org/jenkinsci/plugins/workflow/Puppet.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/Puppet.groovy
@@ -59,8 +59,19 @@ class Puppet implements Serializable {
     Boolean noop = false
     Boolean failOnFailure = true
     Integer concurrency = null
+    ArrayList reports = null
 
     node {
+      if (parameters.reports) {
+        if (parameters.reports instanceof String) {
+          reports << parameters.reports
+        } else if (parameters.reports instanceof ArrayList<String>) {
+          reports = parameters.reports
+        } else {
+          throw "Unknown reports type"
+        }
+      }
+
       if (parameters.credentials) {
         credentials = parameters.credentials
       } else {
@@ -108,7 +119,7 @@ class Puppet implements Serializable {
       }
 
       try {
-        script.puppetJob(environment: env, target: target, concurrency: concurrency, credentialsId: credentials, nodes: nodes, query: query, application: application, noop: noop, failOnFailure: failOnFailure)
+        script.puppetJob(environment: env, target: target, concurrency: concurrency, credentialsId: credentials, nodes: nodes, query: query, application: application, noop: noop, failOnFailure: failOnFailure, reports: reports)
       } catch(err) {
         script.error(message: err.message)
       }

--- a/src/main/resources/org/jenkinsci/plugins/workflow/Puppet.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/Puppet.groovy
@@ -57,7 +57,6 @@ class Puppet implements Serializable {
     String target = null
     ArrayList nodes = null
     Boolean noop = false
-    Boolean failOnFailure = true
     Integer concurrency = null
     ArrayList reports = null
 
@@ -113,13 +112,8 @@ class Puppet implements Serializable {
         script.error(message: "No Credentials provided for puppet.run. Specify 'credentials' parameter or use puppet.credentials()")
       }
 
-      if (parameters.failOnFailure != null) {
-        assert parameters.failOnFailure instanceof Boolean
-        failOnFailure = parameters.failOnFailure
-      }
-
       try {
-        script.puppetJob(environment: env, target: target, concurrency: concurrency, credentialsId: credentials, nodes: nodes, query: query, application: application, noop: noop, failOnFailure: failOnFailure, reports: reports)
+        script.puppetJob(environment: env, target: target, concurrency: concurrency, credentialsId: credentials, nodes: nodes, query: query, application: application, noop: noop, reports: reports)
       } catch(err) {
         script.error(message: err.message)
       }

--- a/src/main/resources/org/jenkinsci/plugins/workflow/Puppet.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/Puppet.groovy
@@ -57,6 +57,7 @@ class Puppet implements Serializable {
     String target = null
     ArrayList nodes = null
     Boolean noop = false
+    Boolean failOnFailure = true
     Integer concurrency = null
 
     node {
@@ -101,8 +102,13 @@ class Puppet implements Serializable {
         script.error(message: "No Credentials provided for puppet.run. Specify 'credentials' parameter or use puppet.credentials()")
       }
 
+      if (parameters.failOnFailure != null) {
+        assert parameters.failOnFailure instanceof Boolean
+        failOnFailure = parameters.failOnFailure
+      }
+
       try {
-        script.puppetJob(environment: env, target: target, concurrency: concurrency, credentialsId: credentials, nodes: nodes, query: query, application: application, noop: noop)
+        script.puppetJob(environment: env, target: target, concurrency: concurrency, credentialsId: credentials, nodes: nodes, query: query, application: application, noop: noop, failOnFailure: failOnFailure)
       } catch(err) {
         script.error(message: err.message)
       }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/PuppetJobStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/PuppetJobStepTest.java
@@ -109,6 +109,13 @@ public class PuppetJobStepTest extends Assert {
             .withHeader("Content-Type", "application/json")
             .withBody(TestUtils.getAPIResponseBody(peVersion, "/orchestrator/v1/jobs/711", "job_details.json"))));
 
+    mockOrchestratorService.stubFor(get(urlEqualTo("/orchestrator/v1/jobs/711/report"))
+        .withHeader("X-Authentication", equalTo("super_secret_token_string"))
+        .willReturn(aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(TestUtils.getAPIResponseBody(peVersion, "/orchestrator/v1/jobs/711/", "job_report.json"))));
+
     mockOrchestratorService.stubFor(get(urlEqualTo("/orchestrator/v1/jobs/711/nodes"))
         .withHeader("X-Authentication", equalTo("super_secret_token_string"))
         .willReturn(aResponse()
@@ -184,6 +191,9 @@ public class PuppetJobStepTest extends Assert {
             .withHeader("Content-Type", matching("application/json")));
 
         verify(getRequestedFor(urlMatching("/orchestrator/v1/jobs/711"))
+            .withHeader("X-Authentication", matching("super_secret_token_string")));
+
+        verify(getRequestedFor(urlMatching("/orchestrator/v1/jobs/711/report"))
             .withHeader("X-Authentication", matching("super_secret_token_string")));
 
         verify(getRequestedFor(urlMatching("/orchestrator/v1/jobs/711/nodes"))

--- a/src/test/java/resources/api-responses/2016.2/orchestrator/v1/jobs/711/job_report.json
+++ b/src/test/java/resources/api-responses/2016.2/orchestrator/v1/jobs/711/job_report.json
@@ -1,0 +1,80 @@
+{
+  "report" : [ {
+    "node" : "database-staging.pdx.puppet.vm",
+    "state" : "finished",
+    "start_timestamp" : "2017-06-05T05:22:17Z",
+    "finish_timestamp" : "2017-06-05T05:22:48Z",
+    "timestamp" : "2017-06-05T05:22:48Z",
+    "events" : [ ]
+  }, {
+    "node" : "database-production.pdx.puppet.vm",
+    "state" : "finished",
+    "start_timestamp" : "2017-06-05T05:22:17Z",
+    "finish_timestamp" : "2017-06-05T05:22:48Z",
+    "timestamp" : "2017-06-05T05:22:48Z",
+    "events" : [ ]
+  }, {
+    "node" : "rgbank-development",
+    "state" : "finished",
+    "start_timestamp" : "2017-06-05T05:22:17Z",
+    "finish_timestamp" : "2017-06-05T05:22:57Z",
+    "timestamp" : "2017-06-05T05:22:57Z",
+    "events" : [ ]
+  }, {
+    "node" : "rgbank-appserver-staging-01.pdx.puppet.vm",
+    "state" : "finished",
+    "start_timestamp" : "2017-06-05T05:22:48Z",
+    "finish_timestamp" : "2017-06-05T05:23:48Z",
+    "timestamp" : "2017-06-05T05:23:48Z",
+    "events" : [ ]
+  }, {
+    "node" : "rgbank-appserver-05.pdx.puppetlabs.vm",
+    "state" : "finished",
+    "start_timestamp" : "2017-06-05T05:22:48Z",
+    "finish_timestamp" : "2017-06-05T05:23:48Z",
+    "timestamp" : "2017-06-05T05:23:48Z",
+    "events" : [ ]
+  }, {
+    "node" : "rgbank-appserver-04.pdx.puppetlabs.vm",
+    "state" : "finished",
+    "start_timestamp" : "2017-06-05T05:22:48Z",
+    "finish_timestamp" : "2017-06-05T05:24:08Z",
+    "timestamp" : "2017-06-05T05:24:08Z",
+    "events" : [ ]
+  }, {
+    "node" : "rgbank-appserver02.pdx.puppetlabs.vm",
+    "state" : "finished",
+    "start_timestamp" : "2017-06-05T05:22:48Z",
+    "finish_timestamp" : "2017-06-05T05:24:08Z",
+    "timestamp" : "2017-06-05T05:24:08Z",
+    "events" : [ ]
+  }, {
+    "node" : "rgbank-appserver03.pdx.puppetlabs.vm",
+    "state" : "finished",
+    "start_timestamp" : "2017-06-05T05:22:48Z",
+    "finish_timestamp" : "2017-06-05T05:24:08Z",
+    "timestamp" : "2017-06-05T05:24:08Z",
+    "events" : [ ]
+  }, {
+    "node" : "rgbank-appserver-01.pdx.puppet.vm",
+    "state" : "finished",
+    "start_timestamp" : "2017-06-05T05:22:48Z",
+    "finish_timestamp" : "2017-06-05T05:24:08Z",
+    "timestamp" : "2017-06-05T05:24:08Z",
+    "events" : [ ]
+  }, {
+    "node" : "rgbank-staging.pdx.puppet.vm",
+    "state" : "finished",
+    "start_timestamp" : "2017-06-05T05:23:48Z",
+    "finish_timestamp" : "2017-06-05T05:24:16Z",
+    "timestamp" : "2017-06-05T05:24:16Z",
+    "events" : [ ]
+  }, {
+    "node" : "rgbank.pdx.puppet.vm",
+    "state" : "finished",
+    "start_timestamp" : "2017-06-05T05:24:08Z",
+    "finish_timestamp" : "2017-06-05T05:24:49Z",
+    "timestamp" : "2017-06-05T05:24:49Z",
+    "events" : [ ]
+  } ]
+}

--- a/src/test/java/resources/api-responses/2016.4/orchestrator/v1/jobs/711/job_report.json
+++ b/src/test/java/resources/api-responses/2016.4/orchestrator/v1/jobs/711/job_report.json
@@ -1,0 +1,80 @@
+{
+  "report" : [ {
+    "node" : "database-staging.pdx.puppet.vm",
+    "state" : "finished",
+    "start_timestamp" : "2017-06-05T05:22:17Z",
+    "finish_timestamp" : "2017-06-05T05:22:48Z",
+    "timestamp" : "2017-06-05T05:22:48Z",
+    "events" : [ ]
+  }, {
+    "node" : "database-production.pdx.puppet.vm",
+    "state" : "finished",
+    "start_timestamp" : "2017-06-05T05:22:17Z",
+    "finish_timestamp" : "2017-06-05T05:22:48Z",
+    "timestamp" : "2017-06-05T05:22:48Z",
+    "events" : [ ]
+  }, {
+    "node" : "rgbank-development",
+    "state" : "finished",
+    "start_timestamp" : "2017-06-05T05:22:17Z",
+    "finish_timestamp" : "2017-06-05T05:22:57Z",
+    "timestamp" : "2017-06-05T05:22:57Z",
+    "events" : [ ]
+  }, {
+    "node" : "rgbank-appserver-staging-01.pdx.puppet.vm",
+    "state" : "finished",
+    "start_timestamp" : "2017-06-05T05:22:48Z",
+    "finish_timestamp" : "2017-06-05T05:23:48Z",
+    "timestamp" : "2017-06-05T05:23:48Z",
+    "events" : [ ]
+  }, {
+    "node" : "rgbank-appserver-05.pdx.puppetlabs.vm",
+    "state" : "finished",
+    "start_timestamp" : "2017-06-05T05:22:48Z",
+    "finish_timestamp" : "2017-06-05T05:23:48Z",
+    "timestamp" : "2017-06-05T05:23:48Z",
+    "events" : [ ]
+  }, {
+    "node" : "rgbank-appserver-04.pdx.puppetlabs.vm",
+    "state" : "finished",
+    "start_timestamp" : "2017-06-05T05:22:48Z",
+    "finish_timestamp" : "2017-06-05T05:24:08Z",
+    "timestamp" : "2017-06-05T05:24:08Z",
+    "events" : [ ]
+  }, {
+    "node" : "rgbank-appserver02.pdx.puppetlabs.vm",
+    "state" : "finished",
+    "start_timestamp" : "2017-06-05T05:22:48Z",
+    "finish_timestamp" : "2017-06-05T05:24:08Z",
+    "timestamp" : "2017-06-05T05:24:08Z",
+    "events" : [ ]
+  }, {
+    "node" : "rgbank-appserver03.pdx.puppetlabs.vm",
+    "state" : "finished",
+    "start_timestamp" : "2017-06-05T05:22:48Z",
+    "finish_timestamp" : "2017-06-05T05:24:08Z",
+    "timestamp" : "2017-06-05T05:24:08Z",
+    "events" : [ ]
+  }, {
+    "node" : "rgbank-appserver-01.pdx.puppet.vm",
+    "state" : "finished",
+    "start_timestamp" : "2017-06-05T05:22:48Z",
+    "finish_timestamp" : "2017-06-05T05:24:08Z",
+    "timestamp" : "2017-06-05T05:24:08Z",
+    "events" : [ ]
+  }, {
+    "node" : "rgbank-staging.pdx.puppet.vm",
+    "state" : "finished",
+    "start_timestamp" : "2017-06-05T05:23:48Z",
+    "finish_timestamp" : "2017-06-05T05:24:16Z",
+    "timestamp" : "2017-06-05T05:24:16Z",
+    "events" : [ ]
+  }, {
+    "node" : "rgbank.pdx.puppet.vm",
+    "state" : "finished",
+    "start_timestamp" : "2017-06-05T05:24:08Z",
+    "finish_timestamp" : "2017-06-05T05:24:49Z",
+    "timestamp" : "2017-06-05T05:24:49Z",
+    "events" : [ ]
+  } ]
+}


### PR DESCRIPTION
This pull requests adds a model for generating orchestrator job reports. It provides the user with the ability to specify types of reports they want. Current options are:
- nodeSummary: The default report. Gives a summary of the number of resources changed per node with a link to the console for a full report.
- nodeChanges: A list of every resource event per node.
- resourceChanges: A list of every resource even and each node that experienced the event.

The user can provide an array of reports so they can view multiple ones if desired.