### PR TITLE
Wait for nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,27 @@ Use the `report` parameter. Multiple reports can be selected by using an array.
   puppet.hiera path: 'host.example.com', key: 'hash-example', value: ['a':1, 'bool':false, 'c': 'string']
 ```
 
+### puppet.waitForNodes
+
+This pipeline step takes a list of nodes and waits up to 30 minutes for them to join the Puppet Enterprise orchestrator (PXP broker).
+This is useful for dynamically provisioning VMs in the pipeline and waiting for them to be ready before kicking off a Puppet orchestrator job.
+
+**Procedural pipeline invocation**: puppet.waitForNodes
+
+**Declarative pipeline invocation**: puppetWaitForNodes
+
+**Parameters**
+
+* credentials - ID of the Jenkins Secret text credentials. String. Required if puppet.credentials not used. Use credentialsId for declarative invocation.
+
+**Example**
+
+```
+  puppet.waitForNodes(['artifactory.inf.puppet.vm','database-production.pdx.puppet.vm'])
+  puppet.waitForNodes(['artifactory.inf.puppet.vm','database-production.pdx.puppet.vm'], credentials: 'access-token')
+```
+
+
 # Compatibility
 
 This plugin is compatible with Puppet Enterprise 2016.2+ and Jenkins 1.642.3+

--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ Use the `report` parameter. Multiple reports can be selected by using an array.
 
 ### puppet.waitForNodes
 
+**NOTE**: This step requires Puppet Enterprise 2016.5+
+
 This pipeline step takes a list of nodes and waits up to 30 minutes for them to join the Puppet Enterprise orchestrator (PXP broker).
 This is useful for dynamically provisioning VMs in the pipeline and waiting for them to be ready before kicking off a Puppet orchestrator job.
 

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetInventoryItemV1.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetInventoryItemV1.java
@@ -1,0 +1,26 @@
+package org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetorchestratorv1;
+
+import java.util.*;
+
+public class PuppetInventoryItemV1 {
+  private Boolean connected = null;
+  private String name = null;
+  private String broker = null;
+  private Date timestamp = null;
+
+  public Boolean getConnected() {
+    return this.connected;
+  }
+
+  public String getName() {
+    return this.name;
+  }
+
+  public String getBroker() {
+    return this.broker;
+  }
+
+  public Date getTimestamp() {
+    return this.timestamp;
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetInventoryV1.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/apimanagers/PuppetOrchestratorV1/PuppetInventoryV1.java
@@ -1,0 +1,74 @@
+package org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetorchestratorv1;
+
+import java.util.*;
+import java.net.URI;
+import java.net.URISyntaxException;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.internal.LinkedTreeMap;
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.PERequest;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.PEResponse;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.PuppetOrchestratorV1;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetorchestratorv1.PuppetOrchestratorException;
+
+public class PuppetInventoryV1 extends PuppetOrchestratorV1 {
+  private URI uri = null;
+  private PuppetInventoryRequest  request  = null;
+  private PuppetInventoryResponse response = null;
+
+  public PuppetInventoryV1() throws Exception {
+    this.uri = getURI("/inventory");
+    this.request = new PuppetInventoryRequest();
+    this.response = new PuppetInventoryResponse();
+  }
+
+  public void setNodes(ArrayList<String> nodes) {
+    this.request.nodes = nodes;
+  }
+
+  private Boolean isSuccessful(PEResponse peResponse) {
+    Integer code = peResponse.getResponseCode();
+    if (code == 400 || code == 404 || code == 401) {
+      return false;
+    }
+
+    return true;
+  }
+
+  public ArrayList<PuppetInventoryItemV1> execute() throws PuppetOrchestratorException, Exception {
+    Gson gson = new Gson();
+    PEResponse peResponse = send(this.uri, request);
+
+    if (isSuccessful(peResponse)) {
+      response = gson.fromJson(peResponse.getJSON(), PuppetInventoryResponse.class);
+    } else {
+      PuppetInventoryError error = gson.fromJson(peResponse.getJSON(), PuppetInventoryError.class);
+      throw new PuppetOrchestratorException(error.kind, error.msg, error.details);
+    }
+
+    return response.getItems();
+  }
+
+  public ArrayList<PuppetInventoryItemV1> getItems() {
+    return response.getItems();
+  }
+
+  class PuppetInventoryRequest {
+    public ArrayList<String> nodes = new ArrayList();
+  }
+
+  class PuppetInventoryResponse {
+    private ArrayList<PuppetInventoryItemV1> items = null;
+
+    private ArrayList<PuppetInventoryItemV1> getItems() {
+      return this.items;
+    }
+  }
+
+  class PuppetInventoryError {
+    public String kind;
+    public String msg;
+    private LinkedTreeMap<String,Object> details;
+  }
+}

--- a/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PuppetJob.java
+++ b/src/main/java/org/jenkinsci/plugins/puppetenterprise/models/PuppetJob.java
@@ -4,6 +4,8 @@ import java.io.*;
 import java.util.*;
 import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetorchestratorv1.PuppetOrchestratorException;
 import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetorchestratorv1.PuppetCommandDeployV1;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetorchestratorv1.PuppetInventoryItemV1;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetorchestratorv1.PuppetInventoryV1;
 import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetorchestratorv1.PuppetJobsIDV1;
 import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetorchestratorv1.puppetjobreportv1.*;
 import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetorchestratorv1.puppetnodev1.*;
@@ -12,6 +14,7 @@ import org.jenkinsci.plugins.puppetenterprise.models.UnknownPuppetJobReportType;
 import com.google.gson.internal.LinkedTreeMap;
 
 public class PuppetJob {
+  private ArrayList<String> inventory = null;
   private String state = null;
   private String name = null;
   private String token = null;
@@ -78,12 +81,36 @@ public class PuppetJob {
     this.evalTrace = evalTrace;
   }
 
+  public void setInventory(ArrayList<String> nodes) {
+    this.inventory = nodes;
+  }
+
+  public ArrayList<String> getInventory() {
+    return this.inventory;
+  }
+
   public String getState() {
     return this.state;
   }
 
   public String getName() {
     return this.name;
+  }
+
+  public Boolean allNodesConnected() throws PuppetOrchestratorException, Exception {
+    PuppetInventoryV1 inventory = new PuppetInventoryV1();
+
+    inventory.setNodes(this.inventory);
+    inventory.setToken(this.token);
+    ArrayList<PuppetInventoryItemV1> inventoryItems = inventory.execute();
+
+    for (PuppetInventoryItemV1 node : inventoryItems) {
+      if (!node.getConnected()) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   public void run() throws PuppetOrchestratorException, Exception {

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/PuppetWaitForNodesStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/PuppetWaitForNodesStep.java
@@ -1,0 +1,146 @@
+package org.jenkinsci.plugins.workflow.steps;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+import java.util.*;
+import com.google.inject.Inject;
+import hudson.Extension;
+import hudson.Util;
+import hudson.util.ListBoxModel;
+import hudson.security.ACL;
+import java.util.ArrayList;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.apache.commons.lang.StringUtils;
+import hudson.model.Run;
+import hudson.model.Item;
+import hudson.model.TaskListener;
+import java.net.*;
+import jenkins.model.Jenkins;
+import javax.annotation.Nonnull;
+
+import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
+import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousStepExecution;
+import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
+import org.jenkinsci.plugins.plaincredentials.*;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.AncestorInPath;
+import java.io.Serializable;
+
+import com.cloudbees.plugins.credentials.CredentialsMatchers;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
+import com.cloudbees.plugins.credentials.domains.URIRequirementBuilder;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import com.google.gson.internal.LinkedTreeMap;
+
+import org.jenkinsci.plugins.puppetenterprise.PuppetEnterpriseManagement;
+import org.jenkinsci.plugins.puppetenterprise.models.PuppetJob;
+import org.jenkinsci.plugins.puppetenterprise.apimanagers.puppetorchestratorv1.PuppetOrchestratorException;
+import org.jenkinsci.plugins.puppetenterprise.models.PEException;
+
+public final class PuppetWaitForNodesStep extends PuppetEnterpriseStep implements Serializable {
+
+  private ArrayList<String> nodes = new ArrayList();
+  private String credentialsId = "";
+
+  @DataBoundSetter private void setNodes(ArrayList nodes) {
+    this.nodes = nodes;
+  }
+
+  public ArrayList getNodes() {
+    return this.nodes;
+  }
+
+  @DataBoundConstructor public PuppetWaitForNodesStep() { }
+
+  public static class PuppetWaitForNodesStepExecution extends AbstractSynchronousStepExecution<Void> {
+
+    @Inject private transient PuppetWaitForNodesStep step;
+    @StepContextParameter private transient Run<?, ?> run;
+    @StepContextParameter private transient TaskListener listener;
+
+    @Override protected Void run() throws Exception {
+      PuppetJob job = new PuppetJob();
+      job.setInventory(step.getNodes());
+      job.setToken(step.getToken());
+      job.setLogger(listener.getLogger());
+
+      try {
+        String summary = "";
+        Integer iterations = 0;
+
+        listener.getLogger().println("Waiting for up to 30 minutes for nodes to connect to Puppet Enterprise.");
+
+        do {
+          try {
+            Thread.sleep(500);
+            iterations = iterations + 1;
+          } catch(InterruptedException ex) {
+            Thread.currentThread().interrupt();
+          }
+        } while (!job.allNodesConnected() && iterations < 3600);
+
+        try {
+          listener.getLogger().println("All " + step.getNodes().size() + " are now connected.");
+        } catch(Exception e) {
+          StringBuilder bug = new StringBuilder();
+          bug.append("You found a bug! The Puppet Enterprise plugin received something ");
+          bug.append("in a job report it wasn't expecting. Please file a ticket here: ");
+          bug.append("https://issues.jenkins-ci.org/browse/JENKINS-42899?jql=project%20%3D%20JENKINS%20AND%20component%20%3D%20'puppet-enterprise-pipeline-plugin'\n\n");
+          bug.append("Include the following information:\n");
+          bug.append("Exception Type: " + e.getClass().getSimpleName() + "\n");
+          bug.append("Exception Message: " + e.getMessage() + "\n");
+
+          throw new Exception(bug.toString());
+        }
+
+      } catch(PuppetOrchestratorException e) {
+        StringBuilder message = new StringBuilder();
+        message.append("Puppet Orchestrator Job Error\n");
+        message.append("Kind:    " + e.getKind() + "\n");
+        message.append("Message: " + e.getMessage() + "\n");
+
+        if (e.getDetails() != null) {
+          message.append("Details: " + e.getDetails().toString() + "\n");
+        }
+
+        throw new PEException(message.toString(), listener);
+      }
+
+      return null;
+    }
+
+    private static final long serialVersionUID = 1L;
+  }
+
+  @Extension public static final class DescriptorImpl extends AbstractStepDescriptorImpl {
+    public DescriptorImpl() {
+      super(PuppetWaitForNodesStepExecution.class);
+    }
+
+    public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item context, @QueryParameter String source) {
+      if (context == null || !context.hasPermission(Item.CONFIGURE)) {
+        return new ListBoxModel();
+      }
+      return new StandardListBoxModel().withEmptySelection().withAll(
+      CredentialsProvider.lookupCredentials(StringCredentials.class, context, ACL.SYSTEM, URIRequirementBuilder.fromUri(source).build()));
+    }
+
+    @Override public String getFunctionName() {
+      return "puppetWaitForNodes";
+    }
+
+    @Override public String getDisplayName() {
+      return "Wait for nodes to join the Puppet Enterprise orchestrator";
+    }
+  }
+}

--- a/src/main/resources/org/jenkinsci/plugins/workflow/Puppet.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/Puppet.groovy
@@ -50,6 +50,25 @@ class Puppet implements Serializable {
     }
   }
 
+  public <V> V waitForNodes(Map parameters = [:], ArrayList nodes) {
+    String credentials
+
+    node {
+      if (parameters.credentials) {
+        credentials = parameters.credentials
+      } else {
+        credentials = credentialsId
+      }
+
+      try {
+        script.puppetWaitForNodes(nodes: nodes, credentialsId: credentials)
+      } catch(err) {
+        script.error(message: err.message)
+      }
+
+    }
+  }
+
   public <V> V job(Map parameters = [:], String env) {
     String credentials
     String application


### PR DESCRIPTION
This PR implements a new pipeline step to wait for nodes to be connected to the PXP broker. The PXP broker is what the Puppet Enterprise orchestrator uses to communicate instantly with agents to kick off Puppet runs.

This is useful for dynamically provisioning VMs (such as in AWS) and waiting for those nodes to become available for orchestration jobs.