### PR TITLE
Return the jobID from the puppetJob step

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/PuppetJobStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/PuppetJobStep.java
@@ -126,7 +126,7 @@ public final class PuppetJobStep extends PuppetEnterpriseStep implements Seriali
 
   @DataBoundConstructor public PuppetJobStep() { }
 
-  public static class PuppetJobStepExecution extends AbstractSynchronousStepExecution<Void> {
+  public static class PuppetJobStepExecution extends AbstractSynchronousStepExecution<String> {
 
     @Inject private transient PuppetJobStep step;
     @StepContextParameter private transient Run<?, ?> run;
@@ -136,7 +136,7 @@ public final class PuppetJobStep extends PuppetEnterpriseStep implements Seriali
       value = "DLS_DEAD_LOCAL_STORE",
       justification = "Findbugs is wrong. The variable is not a dead store."
     )
-    @Override protected Void run() throws Exception {
+    @Override protected String run() throws Exception {
       PuppetJob job = new PuppetJob();
       job.setConcurrency(step.getConcurrency());
       job.setNoop(step.getNoop());
@@ -192,7 +192,7 @@ public final class PuppetJobStep extends PuppetEnterpriseStep implements Seriali
         throw new PEException(message.toString(), listener);
       }
 
-      return null;
+      return job.getName();
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/PuppetJobStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/PuppetJobStepTest.java
@@ -168,7 +168,8 @@ public class PuppetJobStepTest extends Assert {
         WorkflowJob job = story.j.jenkins.createProject(WorkflowJob.class, "Puppet Job with Credentials Defined With Method Call Against " + peVersion);
         job.setDefinition(new CpsFlowDefinition(
           "node { \n" +
-          "  puppet.job 'production', credentials: 'pe-test-token'\n" +
+          "  jobId = puppet.job 'production', credentials: 'pe-test-token'\n" +
+          "  echo \"Returned job id: ${jobId}\"" +
           "}", true));
         WorkflowRun result = job.scheduleBuild2(0).get();
         story.j.assertBuildStatusSuccess(result);
@@ -177,6 +178,7 @@ public class PuppetJobStepTest extends Assert {
         story.j.assertLogContains("State: finished", result);
         story.j.assertLogContains("Environment: production", result);
         story.j.assertLogContains("Nodes: 11", result);
+        story.j.assertLogContains("Returned job id: 711", result);
 
         if (peVersion.equals("2016.2")) {
           //Previous to 2016.4, PE did not support corrective changes


### PR DESCRIPTION
In some cases, it's useful to record or reuse the ID of the job that was
started with the puppetJobStep in your pipeine. Since the ID is already
known in the step, returning it as the step value is a simple change.